### PR TITLE
SDK Code

### DIFF
--- a/packages/core/src/JWTSession.ts
+++ b/packages/core/src/JWTSession.ts
@@ -1,17 +1,43 @@
-// import { v4 as uuidv4 } from 'uuid'
-// import { logger } from './utils/logger'
+import { logger } from './utils/logger'
 import { sessionStorage } from './utils/storage/'
 import { BladeConnect, BladeConnectParams } from './RPCMessages'
-// import {} from './utils/interfaces'
-
+import { SessionOptions } from './utils/interfaces'
 import { Session } from './Session'
 
 export class JWTSession extends Session {
   public WebSocketConstructor = WebSocket
 
-  // constructor(public options: SessionOptions) {
-  //   super(options)
-  // }
+  /**
+   * Can be set a value different then zero
+   * to force the JWT as expired within X seconds.
+   * TODO: Remove this workaround.
+   */
+  private _expiredDiffSeconds = 0
+  private _refreshTokenNotificationDiff = 120
+  /**
+   * Check the JWT expiration every 20seconds
+   */
+  private _checkTokenExpirationDelay = 20
+  private _checkTokenExpirationTimer: any = null
+
+  constructor(public options: SessionOptions) {
+    super(options)
+
+    this._checkTokenExpiration = this._checkTokenExpiration.bind(this)
+  }
+
+  get expiresAt() {
+    return this?._authorization?.expires_at ?? 0
+  }
+
+  get expiresIn() {
+    const now = Math.floor(Date.now() / 1000)
+    return this.expiresAt - now
+  }
+
+  get expired() {
+    return this.expiresIn <= this._expiredDiffSeconds
+  }
 
   /**
    * Authenticate with the SignalWire Network
@@ -29,19 +55,46 @@ export class JWTSession extends Session {
       }
 
       if (this._relayProtocolIsValid()) {
+        params.params = params.params || {}
         params.params.protocol = this.relayProtocol
-      } else {
+      } else if (this.signature) {
         const prevProtocol = await sessionStorage.getItem(this.signature)
         if (prevProtocol) {
+          params.params = params.params || {}
           params.params.protocol = prevProtocol
         }
       }
 
       const response = await this.execute(BladeConnect(params))
+      this._authorization = response.authorization
+      this._checkTokenExpiration()
       console.log('Response', response)
       // TODO: check JWT expires_at and handle re-auth
     } catch (error) {
       console.error('Auth Error', error)
+    }
+  }
+
+  /**
+   * Set a timer to dispatch a notification when the JWT is going to expire.
+   * @return void
+   */
+  protected _checkTokenExpiration() {
+    if (!this.expiresAt) {
+      return
+    }
+    if (this.expiresIn <= this._refreshTokenNotificationDiff) {
+      logger.debug(
+        'Your JWT is going to expire. Please refresh it to keep the session live.'
+      )
+      // trigger(SwEvent.Notification, { type: Notification.RefreshToken, session: this }, this.uuid, false)
+    }
+    clearTimeout(this._checkTokenExpirationTimer)
+    if (!this.expired) {
+      this._checkTokenExpirationTimer = setTimeout(
+        this._checkTokenExpiration,
+        this._checkTokenExpirationDelay
+      )
     }
   }
 }

--- a/packages/core/src/JWTSession.ts
+++ b/packages/core/src/JWTSession.ts
@@ -1,0 +1,47 @@
+// import { v4 as uuidv4 } from 'uuid'
+// import { logger } from './utils/logger'
+import { sessionStorage } from './utils/storage/'
+import { BladeConnect, BladeConnectParams } from './RPCMessages'
+// import {} from './utils/interfaces'
+
+import { Session } from './Session'
+
+export class JWTSession extends Session {
+  public WebSocketConstructor = WebSocket
+
+  // constructor(public options: SessionOptions) {
+  //   super(options)
+  // }
+
+  /**
+   * Authenticate with the SignalWire Network
+   * using JWT
+   * @return Promise<void>
+   */
+  async authenticate() {
+    try {
+      const params: BladeConnectParams = {
+        authentication: {
+          project: this.options.project,
+          jwt_token: this.options.token,
+        },
+        params: {},
+      }
+
+      if (this._relayProtocolIsValid()) {
+        params.params.protocol = this.relayProtocol
+      } else {
+        const prevProtocol = await sessionStorage.getItem(this.signature)
+        if (prevProtocol) {
+          params.params.protocol = prevProtocol
+        }
+      }
+
+      const response = await this.execute(BladeConnect(params))
+      console.log('Response', response)
+      // TODO: check JWT expires_at and handle re-auth
+    } catch (error) {
+      console.error('Auth Error', error)
+    }
+  }
+}

--- a/packages/core/src/RPCMessages/BladeConnect.ts
+++ b/packages/core/src/RPCMessages/BladeConnect.ts
@@ -1,4 +1,4 @@
-import { makeRPCRequest } from './index'
+import { makeRPCRequest } from './helpers'
 import { BladeMethod } from '../utils/constants'
 
 const BLADE_VERSION = {
@@ -7,14 +7,14 @@ const BLADE_VERSION = {
   revision: 0,
 }
 
-let agent: string = null
+let agent: string | null = null
 export const setAgentName = (name: string) => {
   agent = name
 }
 
 type WithToken = { token: string; jwt_token?: never }
 type WithJWT = { token?: never; jwt_token: string }
-type BladeConnectAuthentication = ({ project: string } & WithToken) | WithJWT
+type BladeConnectAuthentication = { project: string } & (WithToken | WithJWT)
 export type BladeConnectParams = {
   authentication: BladeConnectAuthentication
   params?: {

--- a/packages/core/src/RPCMessages/BladeConnect.ts
+++ b/packages/core/src/RPCMessages/BladeConnect.ts
@@ -1,0 +1,35 @@
+import { makeRPCRequest } from './index'
+import { BladeMethod } from '../utils/constants'
+
+const BLADE_VERSION = {
+  major: 2,
+  minor: 5,
+  revision: 0,
+}
+
+let agent: string = null
+export const setAgentName = (name: string) => {
+  agent = name
+}
+
+type WithToken = { token: string; jwt_token?: never }
+type WithJWT = { token?: never; jwt_token: string }
+type BladeConnectAuthentication = ({ project: string } & WithToken) | WithJWT
+export type BladeConnectParams = {
+  authentication: BladeConnectAuthentication
+  params?: {
+    protocol?: string
+    contexts?: string[]
+  }
+}
+
+export const BladeConnect = (params: BladeConnectParams) => {
+  return makeRPCRequest({
+    method: BladeMethod.Connect,
+    params: {
+      version: BLADE_VERSION,
+      agent,
+      ...params,
+    },
+  })
+}

--- a/packages/core/src/RPCMessages/BladeDisconnect.ts
+++ b/packages/core/src/RPCMessages/BladeDisconnect.ts
@@ -1,0 +1,8 @@
+import { makeRPCResponse } from './index'
+
+export const BladeDisconnectResponse = (id: string) => {
+  return makeRPCResponse({
+    id,
+    result: {},
+  })
+}

--- a/packages/core/src/RPCMessages/BladeDisconnect.ts
+++ b/packages/core/src/RPCMessages/BladeDisconnect.ts
@@ -1,4 +1,4 @@
-import { makeRPCResponse } from './index'
+import { makeRPCResponse } from './helpers'
 
 export const BladeDisconnectResponse = (id: string) => {
   return makeRPCResponse({

--- a/packages/core/src/RPCMessages/BladeExecute.ts
+++ b/packages/core/src/RPCMessages/BladeExecute.ts
@@ -1,4 +1,4 @@
-import { makeRPCRequest } from './index'
+import { makeRPCRequest } from './helpers'
 import { BladeMethod } from '../utils/constants'
 
 type BladeExecuteParams = {

--- a/packages/core/src/RPCMessages/BladeExecute.ts
+++ b/packages/core/src/RPCMessages/BladeExecute.ts
@@ -1,0 +1,17 @@
+import { makeRPCRequest } from './index'
+import { BladeMethod } from '../utils/constants'
+
+type BladeExecuteParams = {
+  protocol: string
+  method: string
+  params?: {
+    [key: string]: any
+  }
+}
+
+export const BladeExecute = (params: BladeExecuteParams) => {
+  return makeRPCRequest({
+    method: BladeMethod.Execute,
+    params,
+  })
+}

--- a/packages/core/src/RPCMessages/BladePing.ts
+++ b/packages/core/src/RPCMessages/BladePing.ts
@@ -1,0 +1,20 @@
+import { makeRPCRequest, makeRPCResponse } from './index'
+import { BladeMethod } from '../utils/constants'
+
+export const BladePing = () => {
+  return makeRPCRequest({
+    method: BladeMethod.Ping,
+    params: {
+      timestamp: Date.now() / 1000,
+    },
+  })
+}
+
+export const BladePingResponse = (id: string, timestamp?: number) => {
+  return makeRPCResponse({
+    id,
+    result: {
+      timestamp: timestamp || Date.now() / 1000,
+    },
+  })
+}

--- a/packages/core/src/RPCMessages/BladePing.ts
+++ b/packages/core/src/RPCMessages/BladePing.ts
@@ -1,4 +1,4 @@
-import { makeRPCRequest, makeRPCResponse } from './index'
+import { makeRPCRequest, makeRPCResponse } from './helpers'
 import { BladeMethod } from '../utils/constants'
 
 export const BladePing = () => {

--- a/packages/core/src/RPCMessages/BladeReauthenticate.ts
+++ b/packages/core/src/RPCMessages/BladeReauthenticate.ts
@@ -1,4 +1,4 @@
-import { makeRPCRequest } from './index'
+import { makeRPCRequest } from './helpers'
 import { BladeMethod } from '../utils/constants'
 
 type BladeReauthenticateParams = { project: string; jwt_token: string }

--- a/packages/core/src/RPCMessages/BladeReauthenticate.ts
+++ b/packages/core/src/RPCMessages/BladeReauthenticate.ts
@@ -1,0 +1,15 @@
+import { makeRPCRequest } from './index'
+import { BladeMethod } from '../utils/constants'
+
+type BladeReauthenticateParams = { project: string; jwt_token: string }
+
+export const BladeReauthenticate = (
+  authentication: BladeReauthenticateParams
+) => {
+  return makeRPCRequest({
+    method: BladeMethod.Reauthenticate,
+    params: {
+      authentication,
+    },
+  })
+}

--- a/packages/core/src/RPCMessages/helpers.ts
+++ b/packages/core/src/RPCMessages/helpers.ts
@@ -1,6 +1,6 @@
 import { uuid } from '../utils'
 
-type MakeRPCRequestParams = {
+interface MakeRPCRequestParams {
   method: string // TODO: use enum
   params: {
     // TODO: use list of types?
@@ -15,7 +15,7 @@ export const makeRPCRequest = (params: MakeRPCRequestParams) => {
   }
 }
 
-type MakeRPCResponseParams = {
+interface MakeRPCResponseParams {
   id: string
   result: {
     // TODO: use list of types?

--- a/packages/core/src/RPCMessages/helpers.ts
+++ b/packages/core/src/RPCMessages/helpers.ts
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from 'uuid'
+import { uuid } from '../utils'
 
 type MakeRPCRequestParams = {
   method: string // TODO: use enum
@@ -10,7 +10,7 @@ type MakeRPCRequestParams = {
 export const makeRPCRequest = (params: MakeRPCRequestParams) => {
   return {
     jsonrpc: '2.0' as const,
-    id: uuidv4(),
+    id: uuid(),
     ...params,
   }
 }

--- a/packages/core/src/RPCMessages/helpers.ts
+++ b/packages/core/src/RPCMessages/helpers.ts
@@ -1,0 +1,30 @@
+import { v4 as uuidv4 } from 'uuid'
+
+type MakeRPCRequestParams = {
+  method: string // TODO: use enum
+  params: {
+    // TODO: use list of types?
+    [key: string]: any
+  }
+}
+export const makeRPCRequest = (params: MakeRPCRequestParams) => {
+  return {
+    jsonrpc: '2.0' as const,
+    id: uuidv4(),
+    ...params,
+  }
+}
+
+type MakeRPCResponseParams = {
+  id: string
+  result: {
+    // TODO: use list of types?
+    [key: string]: any
+  }
+}
+export const makeRPCResponse = (params: MakeRPCResponseParams) => {
+  return {
+    jsonrpc: '2.0' as const,
+    ...params,
+  }
+}

--- a/packages/core/src/RPCMessages/index.test.ts
+++ b/packages/core/src/RPCMessages/index.test.ts
@@ -1,0 +1,175 @@
+import {
+  BladeConnect,
+  setAgentName,
+  BladeReauthenticate,
+  BladePing,
+  BladePingResponse,
+  BladeExecute,
+  BladeDisconnectResponse,
+} from './index'
+
+jest.mock('uuid', () => {
+  return {
+    v4: jest.fn(() => 'mocked-uuid'),
+  }
+})
+
+describe('RPC Messages', () => {
+  describe('BladeConnect', () => {
+    it('should generate the message with token', function () {
+      const authentication = { project: 'project', token: 'token' }
+      const message = BladeConnect({ authentication })
+      expect(message).toStrictEqual({
+        jsonrpc: '2.0',
+        id: 'mocked-uuid',
+        method: 'blade.connect',
+        params: {
+          authentication: { project: 'project', token: 'token' },
+          version: { major: 2, minor: 5, revision: 0 },
+          agent: null,
+        },
+      })
+    })
+
+    it('should generate the message using sub-params', function () {
+      const authentication = { project: 'project', token: 'token' }
+      const message = BladeConnect({
+        authentication,
+        params: { protocol: 'old-proto', contexts: ['test'] },
+      })
+      expect(message).toStrictEqual({
+        jsonrpc: '2.0',
+        id: 'mocked-uuid',
+        method: 'blade.connect',
+        params: {
+          authentication: { project: 'project', token: 'token' },
+          version: { major: 2, minor: 5, revision: 0 },
+          agent: null,
+          params: {
+            protocol: 'old-proto',
+            contexts: ['test'],
+          },
+        },
+      })
+    })
+
+    it('should generate the message with jwt_token', function () {
+      const authentication = { project: 'project', jwt_token: 'jwt' }
+      const message = BladeConnect({ authentication })
+      expect(message).toStrictEqual({
+        jsonrpc: '2.0',
+        id: 'mocked-uuid',
+        method: 'blade.connect',
+        params: {
+          authentication: { project: 'project', jwt_token: 'jwt' },
+          version: { major: 2, minor: 5, revision: 0 },
+          agent: null,
+        },
+      })
+    })
+
+    it('should generate the message using agent', function () {
+      setAgentName('Jest Random Test')
+      const authentication = { project: 'project', jwt_token: 'jwt' }
+      const message = BladeConnect({ authentication })
+      expect(message).toStrictEqual({
+        jsonrpc: '2.0',
+        id: 'mocked-uuid',
+        method: 'blade.connect',
+        params: {
+          authentication: { project: 'project', jwt_token: 'jwt' },
+          version: { major: 2, minor: 5, revision: 0 },
+          agent: 'Jest Random Test',
+        },
+      })
+    })
+  })
+
+  describe('BladeReauthenticate', () => {
+    it('should generate the message', function () {
+      const message = BladeReauthenticate({
+        project: 'project',
+        jwt_token: 'jwt',
+      })
+      expect(message).toStrictEqual({
+        jsonrpc: '2.0',
+        id: 'mocked-uuid',
+        method: 'blade.reauthenticate',
+        params: {
+          authentication: { project: 'project', jwt_token: 'jwt' },
+        },
+      })
+    })
+  })
+
+  describe('BladePing', () => {
+    it('should generate the message', function () {
+      global.Date.now = jest.fn(() => 1581442824134)
+
+      const message = BladePing()
+      expect(message).toStrictEqual({
+        jsonrpc: '2.0',
+        id: 'mocked-uuid',
+        method: 'blade.ping',
+        params: {
+          timestamp: 1581442824134 / 1000,
+        },
+      })
+    })
+
+    it('should generate the response', function () {
+      const message = BladePingResponse('uuid', 1234)
+      expect(message).toStrictEqual({
+        jsonrpc: '2.0',
+        id: 'uuid',
+        result: {
+          timestamp: 1234,
+        },
+      })
+    })
+  })
+
+  describe('BladeExecute', () => {
+    it('should generate the message based on protocol and method', function () {
+      const message = BladeExecute({ protocol: 'example', method: 'sum' })
+      expect(message).toStrictEqual({
+        jsonrpc: '2.0',
+        id: 'mocked-uuid',
+        method: 'blade.execute',
+        params: {
+          protocol: 'example',
+          method: 'sum',
+        },
+      })
+    })
+
+    it('should generate the message based on protocol, method and specific params', function () {
+      const message = BladeExecute({
+        protocol: 'example',
+        method: 'sum',
+        params: { x: 3, y: 6 },
+      })
+      expect(message).toStrictEqual({
+        jsonrpc: '2.0',
+        id: 'mocked-uuid',
+        method: 'blade.execute',
+        params: {
+          protocol: 'example',
+          method: 'sum',
+          params: { x: 3, y: 6 },
+        },
+      })
+    })
+  })
+
+  describe('BladeDisconnect', () => {
+    it('should generate the response', function () {
+      const message = BladeDisconnectResponse('uuid')
+      expect(message).toStrictEqual({
+        jsonrpc: '2.0',
+        id: 'uuid',
+        result: {},
+      })
+    })
+  })
+})

--- a/packages/core/src/RPCMessages/index.ts
+++ b/packages/core/src/RPCMessages/index.ts
@@ -1,34 +1,3 @@
-import { v4 as uuidv4 } from 'uuid'
-
-type MakeRPCRequestParams = {
-  method: string // TODO: use enum
-  params: {
-    // TODO: use list of types?
-    [key: string]: any
-  }
-}
-export const makeRPCRequest = (params: MakeRPCRequestParams) => {
-  return {
-    jsonrpc: '2.0' as const,
-    id: uuidv4(),
-    ...params,
-  }
-}
-
-type MakeRPCResponseParams = {
-  id: string
-  result: {
-    // TODO: use list of types?
-    [key: string]: any
-  }
-}
-export const makeRPCResponse = (params: MakeRPCResponseParams) => {
-  return {
-    jsonrpc: '2.0' as const,
-    ...params,
-  }
-}
-
 export * from './BladeConnect'
 export * from './BladeReauthenticate'
 export * from './BladePing'

--- a/packages/core/src/RPCMessages/index.ts
+++ b/packages/core/src/RPCMessages/index.ts
@@ -1,0 +1,36 @@
+import { v4 as uuidv4 } from 'uuid'
+
+type MakeRPCRequestParams = {
+  method: string // TODO: use enum
+  params: {
+    // TODO: use list of types?
+    [key: string]: any
+  }
+}
+export const makeRPCRequest = (params: MakeRPCRequestParams) => {
+  return {
+    jsonrpc: '2.0' as const,
+    id: uuidv4(),
+    ...params,
+  }
+}
+
+type MakeRPCResponseParams = {
+  id: string
+  result: {
+    // TODO: use list of types?
+    [key: string]: any
+  }
+}
+export const makeRPCResponse = (params: MakeRPCResponseParams) => {
+  return {
+    jsonrpc: '2.0' as const,
+    ...params,
+  }
+}
+
+export * from './BladeConnect'
+export * from './BladeReauthenticate'
+export * from './BladePing'
+export * from './BladeExecute'
+export * from './BladeDisconnect'

--- a/packages/core/src/Session.ts
+++ b/packages/core/src/Session.ts
@@ -1,5 +1,4 @@
-import { v4 as uuidv4 } from 'uuid'
-import { logger } from './utils/logger'
+import { uuid, logger } from './utils'
 import { BladeMethod, DEFAULT_HOST, WebSocketState } from './utils/constants'
 import {
   BladeConnect,
@@ -24,8 +23,8 @@ import {
 } from './utils'
 
 export class Session {
-  public uuid: string = uuidv4()
-  public relayProtocol: string = ''
+  public uuid = uuid()
+  public relayProtocol = ''
   public WebSocketConstructor: typeof WebSocket
 
   protected _authorization: IBladeAuthorization

--- a/packages/core/src/Session.ts
+++ b/packages/core/src/Session.ts
@@ -1,0 +1,272 @@
+import { v4 as uuidv4 } from 'uuid'
+import { logger } from './utils/logger'
+import { BladeMethod, DEFAULT_HOST, WebSocketState } from './utils/constants'
+import {
+  BladeConnect,
+  BladeConnectParams,
+  BladeDisconnectResponse,
+  BladePingResponse,
+} from './RPCMessages'
+import {
+  SessionOptions,
+  SessionRequestObject,
+  SessionRequestQueued,
+  IBladeAuthorization,
+  JSONRPCRequest,
+  JSONRPCResponse,
+} from './utils/interfaces'
+
+import {
+  checkWebSocketHost,
+  timeoutPromise,
+  destructResponse,
+  safeParseJson,
+} from './utils'
+
+export class Session {
+  public uuid: string = uuidv4()
+  public relayProtocol: string = null
+  public WebSocketConstructor: typeof WebSocket
+
+  private _requests = new Map<string, SessionRequestObject>()
+  private _requestQueue: SessionRequestQueued[] = []
+  private _socket: WebSocket = null
+  private _idle = true
+  private _host: string = DEFAULT_HOST
+  private _authorization: IBladeAuthorization
+
+  private _executeTimeoutMs = 10 * 1000
+  private _executeTimeoutError = Symbol.for('sw-execute-timeout')
+
+  // private _pingTimeout = null
+  // private _pingDelay = 15 * 1000
+
+  // validateOptions(): boolean
+  // eventHandler(notification: any): void
+
+  constructor(public options: SessionOptions) {
+    // if (!this.validateOptions()) {
+    //   throw new Error('Invalid init options')
+    // }
+    if (options.host) {
+      this._host = checkWebSocketHost(options.host)
+    }
+    this._onSocketOpen = this._onSocketOpen.bind(this)
+    this._onSocketError = this._onSocketError.bind(this)
+    this._onSocketClose = this._onSocketClose.bind(this)
+    this._onSocketMessage = this._onSocketMessage.bind(this)
+
+    this.logger.setLevel(this.logger.levels.DEBUG)
+  }
+
+  get signature() {
+    return this?._authorization.signature
+  }
+
+  get logger(): typeof logger {
+    return logger
+  }
+
+  get connecting() {
+    return this._socket?.readyState === WebSocketState.CONNECTING
+  }
+
+  get connected() {
+    return this._socket?.readyState === WebSocketState.OPEN
+  }
+
+  get closing() {
+    return this._socket?.readyState === WebSocketState.CLOSING
+  }
+
+  get closed() {
+    return this._socket?.readyState === WebSocketState.CLOSED
+  }
+
+  /**
+   * Connect the websocket
+   *
+   * @return void
+   */
+  connect(): void {
+    /**
+     * Return if there is already a _socket instance.
+     * This prevents issues if "connect()" is called multiple times.
+     */
+    if (this._socket) {
+      logger.warn('Session already connected.')
+      return
+    }
+    this._socket = new this.WebSocketConstructor(this._host)
+    this._socket.onopen = this._onSocketOpen
+    this._socket.onclose = this._onSocketClose
+    this._socket.onerror = this._onSocketError
+    this._socket.onmessage = this._onSocketMessage
+  }
+
+  /**
+   * Remove subscriptions and calls, close WS connection and remove all session listeners.
+   * @return void
+   */
+  async disconnect() {
+    /**
+     * Return if there is not a _socket instance or
+     * if it's already in closing state.
+     */
+    if (!this._socket || this.closing) {
+      logger.warn('Session not connected or already in closing state.')
+      return
+    }
+
+    this._socket.close()
+    this._socket = null
+    // clearTimeout(this._reconnectTimeout)
+    // this.subscriptions.clear()
+    // this._autoReconnect = false
+    // this.relayProtocol = null
+    // this._closeConnection()
+    // await sessionStorage.removeItem(this.signature)
+    // this._executeQueue = []
+    // this._detachListeners()
+    // this.off(SwEvent.Ready)
+    // this.off(SwEvent.Notification)
+    // this.off(SwEvent.Error)
+  }
+
+  /**
+   * Send a JSON object to the server.
+   * @return Promise that will resolve/reject depending on the server response
+   */
+  execute(msg: JSONRPCRequest | JSONRPCResponse): Promise<any> {
+    if (this._idle) {
+      return new Promise((resolve) => this._requestQueue.push({ resolve, msg }))
+    }
+    if (!this.connected) {
+      return new Promise((resolve) => {
+        this._requestQueue.push({ resolve, msg })
+        this.connect()
+      })
+    }
+    let promise: Promise<unknown> = null
+    if ('params' in msg) {
+      // This is a request so save the "id" to resolve the Promise later
+      promise = new Promise((resolve, reject) => {
+        this._requests.set(msg.id, { resolve, reject })
+      })
+    } else {
+      // This is a response so don't wait for a result
+      promise = Promise.resolve()
+    }
+
+    logger.debug('SEND: \n', JSON.stringify(msg, null, 2), '\n')
+    this._socket.send(JSON.stringify(msg))
+
+    return timeoutPromise(
+      promise,
+      this._executeTimeoutMs,
+      this._executeTimeoutError
+    ).catch((error) => {
+      if (error === this._executeTimeoutError) {
+        logger.error('Request Timeout', msg)
+        // FIXME: Timeout so close/reconnect
+        // this._closeConnection()
+      } else {
+        throw error
+      }
+    })
+  }
+
+  /**
+   * Authenticate with the SignalWire Network
+   * @return Promise<void>
+   */
+  async authenticate() {
+    try {
+      const params: BladeConnectParams = {
+        authentication: {
+          project: this.options.project,
+          token: this.options.token,
+        },
+        params: {},
+      }
+      if (this._relayProtocolIsValid()) {
+        params.params.protocol = this.relayProtocol
+      }
+      const response = await this.execute(BladeConnect(params))
+      console.log('Response', response)
+    } catch (error) {
+      console.error('Auth Error', error)
+    }
+  }
+
+  protected async _onSocketOpen(event: Event) {
+    logger.debug('_onSocketOpen', event)
+    this._idle = false
+    await this.authenticate()
+    this._emptyRequestQueue()
+  }
+
+  protected _onSocketError(event: Event) {
+    logger.debug('_onSocketError', event)
+  }
+
+  protected _onSocketClose(event: CloseEvent) {
+    logger.debug('_onSocketClose', event)
+  }
+
+  protected _onSocketMessage(event: MessageEvent) {
+    const payload: any = safeParseJson(event.data)
+    logger.debug('RECV: \n', JSON.stringify(payload, null, 2), '\n')
+    if (this._requests.has(payload.id)) {
+      const { resolve, reject } = this._requests.get(payload.id)
+      this._requests.delete(payload.id)
+      const { result, error } = destructResponse(payload)
+      return error ? reject(error) : resolve(result)
+    }
+
+    switch (payload.method) {
+      case BladeMethod.Ping: {
+        // TODO: check missing ping within 15 seconds and close connection
+        const response = BladePingResponse(
+          payload.id,
+          payload?.params?.timestamp
+        )
+        this.execute(response)
+        break
+      }
+      case BladeMethod.Disconnect: {
+        /**
+         * Set _idle = true because the server
+         * will close the connection soon.
+         */
+        this._idle = true
+        this.execute(BladeDisconnectResponse(payload.id))
+        break
+      }
+      default:
+        // If it's not a response, trigger the eventHandler.
+        // this.eventHandler(payload)
+        logger.warn('Event', payload)
+    }
+  }
+
+  /**
+   * Check the current relayProtocol against the signature
+   * to make sure is still valid.
+   * @return boolean
+   */
+  protected _relayProtocolIsValid() {
+    return this?.relayProtocol?.split('_')[1] === this.signature
+  }
+
+  /**
+   * Execute all the queued messages during the idle period.
+   * @return void
+   */
+  private _emptyRequestQueue() {
+    this._requestQueue.forEach(({ resolve, msg }) => {
+      resolve(this.execute(msg))
+    })
+    this._requestQueue = []
+  }
+}

--- a/packages/core/src/Session.ts
+++ b/packages/core/src/Session.ts
@@ -28,12 +28,13 @@ export class Session {
   public relayProtocol: string = null
   public WebSocketConstructor: typeof WebSocket
 
+  protected _authorization: IBladeAuthorization
+
   private _requests = new Map<string, SessionRequestObject>()
   private _requestQueue: SessionRequestQueued[] = []
   private _socket: WebSocket = null
   private _idle = true
   private _host: string = DEFAULT_HOST
-  private _authorization: IBladeAuthorization
 
   private _executeTimeoutMs = 10 * 1000
   private _executeTimeoutError = Symbol.for('sw-execute-timeout')
@@ -194,6 +195,7 @@ export class Session {
       }
       const response = await this.execute(BladeConnect(params))
       console.log('Response', response)
+      this._authorization = response.authorization
     } catch (error) {
       console.error('Auth Error', error)
     }

--- a/packages/core/src/Session.ts
+++ b/packages/core/src/Session.ts
@@ -61,7 +61,7 @@ export class Session {
   }
 
   get signature() {
-    return this?._authorization.signature
+    return this?._authorization?.signature
   }
 
   get logger(): typeof logger {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,4 @@
-import { v4 as uuid } from 'uuid'
-import { logger } from './utils/logger'
+import { uuid, logger } from './utils'
 import { Session } from './Session'
 import { JWTSession } from './JWTSession'
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,12 @@
 import { v4 as uuid } from 'uuid'
-
 import { logger } from './utils/logger'
+import { Session } from './Session'
+import { JWTSession } from './JWTSession'
 
-export { uuid, logger }
+// prettier-ignore
+export {
+  uuid,
+  logger,
+  Session,
+  JWTSession,
+}

--- a/packages/core/src/utils/PubSub.test.ts
+++ b/packages/core/src/utils/PubSub.test.ts
@@ -1,0 +1,131 @@
+import { EventPubSub } from './PubSub'
+
+describe('EventPubSub Class', () => {
+  let instance: EventPubSub = null
+  const exampleData = {
+    test: 'data',
+    random: 'data',
+  }
+  const eventName = 'event'
+
+  beforeEach(() =>{
+    instance = new EventPubSub()
+  })
+
+  describe('.on() method', () => {
+    it('should append an handler for the specified eventName', () => {
+      const mockCallback = jest.fn()
+      instance.on(eventName, mockCallback)
+
+      instance.emit(eventName, exampleData)
+      instance.emit(eventName, 'other stuff')
+
+      expect(mockCallback).toHaveBeenCalledTimes(2)
+      expect(mockCallback).toHaveBeenNthCalledWith(1, exampleData)
+      expect(mockCallback).toHaveBeenNthCalledWith(2, 'other stuff')
+    })
+
+    it('should append multiple handlers for the same eventName', () => {
+      const mockCallback = jest.fn()
+      instance.on(eventName, mockCallback)
+      instance.on(eventName, mockCallback)
+
+      const anotherMockCallback = jest.fn()
+      instance.on('another-event', anotherMockCallback)
+
+      instance.emit(eventName, exampleData)
+
+      expect(mockCallback).toHaveBeenCalledTimes(2)
+      expect(mockCallback).toHaveBeenNthCalledWith(1, exampleData)
+      expect(mockCallback).toHaveBeenNthCalledWith(2, exampleData)
+
+      expect(anotherMockCallback).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('.once() method', () => {
+    it('should trigger the callback just once', () => {
+      const mockCallback = jest.fn()
+      instance.once(eventName, mockCallback)
+
+      instance.emit(eventName, 'one time only!')
+      instance.emit(eventName, 'one time only!')
+      instance.emit(eventName, 'one time only!')
+
+      expect(mockCallback).toHaveBeenCalledTimes(1)
+      expect(mockCallback).toHaveBeenNthCalledWith(1, 'one time only!')
+    })
+
+    it('should trigger the callback when called multiple times', () => {
+      const mockCallback = jest.fn()
+      instance.once(eventName, mockCallback)
+      instance.once(eventName, mockCallback)
+      instance.once(eventName, mockCallback)
+
+      instance.emit(eventName, exampleData)
+
+      expect(mockCallback).toHaveBeenCalledTimes(3)
+      expect(mockCallback).toHaveBeenCalledWith(exampleData)
+    })
+  })
+
+  describe('.off() method', () => {
+    it('should remove the callback from the queue added with on', () => {
+      const mockCallback = jest.fn()
+      instance.on(eventName, mockCallback)
+
+      instance.emit(eventName, exampleData)
+      instance.off(eventName, mockCallback)
+
+      instance.emit(eventName, 'no-op')
+      instance.emit(eventName, 'no-op')
+
+      expect(mockCallback).toHaveBeenCalledTimes(1)
+      expect(mockCallback).toHaveBeenNthCalledWith(1, exampleData)
+    })
+
+    it('should remove the callback from the queue added with once', () => {
+      const mockCallback = jest.fn()
+      instance.once(eventName, mockCallback)
+      instance.off(eventName, mockCallback)
+
+      instance.emit(eventName, 'no-op')
+
+      expect(mockCallback).not.toHaveBeenCalled()
+    })
+
+    it('should remove all the callbacks from the queue without the handler as argument', () => {
+      const mockCallback = jest.fn()
+      instance.on(eventName, mockCallback)
+
+      instance.off(eventName)
+
+      instance.emit(eventName, 'no-op')
+
+      expect(mockCallback).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('.reset() method', () => {
+    it('should reset the queue', () => {
+      const mockCallback1 = jest.fn()
+      instance.on(eventName, mockCallback1)
+
+      const mockCallback2 = jest.fn()
+      instance.on('otherEvent', mockCallback2)
+
+      const mockCallback3 = jest.fn()
+      instance.on('anotherEvent', mockCallback3)
+
+      instance.reset()
+
+      instance.emit(eventName, 'no-op')
+      instance.emit('otherEvent', 'no-op')
+      instance.emit('anotherEvent', 'no-op')
+
+      expect(mockCallback1).not.toHaveBeenCalled()
+      expect(mockCallback2).not.toHaveBeenCalled()
+      expect(mockCallback3).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/core/src/utils/PubSub.ts
+++ b/packages/core/src/utils/PubSub.ts
@@ -1,0 +1,64 @@
+export class EventPubSub {
+
+  private _queue: { [key: string]: Function[] } = {}
+  private _uniqueKey = Symbol.for('sw-once-key')
+
+  on(eventName: string, handler: Function, once = false) {
+    if (!this._queue[eventName]) {
+      this._queue[eventName] = []
+    }
+    this._queue[eventName].push(handler)
+    handler[this._uniqueKey] = once
+    return this
+  }
+
+  once(eventName: string, handler: Function) {
+    return this.on(eventName, handler, true)
+  }
+
+  off(eventName: string, handler: Function = null) {
+    if (!this._queue[eventName]) {
+      return this
+    }
+
+    if (!handler) {
+      delete this._queue[eventName]
+      return this
+    }
+
+    const handlers = this._queue[eventName]
+    while (handlers.includes(handler)) {
+      handlers.splice(handlers.indexOf( handler ), 1)
+    }
+    if (!handlers.length) {
+      delete this._queue[eventName]
+    }
+    return this
+  }
+
+  emit(eventName: string, ...args: any[]) {
+    if (!this._queue[eventName]) {
+      return this
+    }
+    const handlers = this._queue[eventName]
+    const deleteOnceHandled = []
+    for (let handler of handlers) {
+      handler(...args)
+      if (handler[this._uniqueKey]) {
+        deleteOnceHandled.push(handler)
+      }
+    }
+    for(let handler of deleteOnceHandled){
+      this.off(eventName, handler)
+    }
+    return this
+  }
+
+  reset() {
+    for(let eventName in this._queue){
+      this.off(eventName)
+    }
+
+    return this
+  }
+}

--- a/packages/core/src/utils/constants.ts
+++ b/packages/core/src/utils/constants.ts
@@ -1,0 +1,45 @@
+export const STORAGE_PREFIX = '@signalwire:'
+export const ADD = 'add'
+export const REMOVE = 'remove'
+export const SESSION_ID = 'sessId'
+export const VERTO_PROTOCOL = 'verto-protocol'
+export const DEFAULT_HOST = 'wss://relay.signalwire.com'
+
+export enum WebSocketState {
+  CONNECTING = 0,
+  OPEN = 1,
+  CLOSING = 2,
+  CLOSED = 3,
+}
+
+export enum BladeMethod {
+  Broadcast = 'blade.broadcast',
+  Disconnect = 'blade.disconnect',
+  Connect = 'blade.connect',
+  Ping = 'blade.ping',
+  Reauthenticate = 'blade.reauthenticate',
+  Execute = 'blade.execute',
+}
+
+// export enum SwEvent {
+//   // Socket Events
+//   SocketOpen = 'signalwire.socket.open',
+//   SocketClose = 'signalwire.socket.close',
+//   SocketError = 'signalwire.socket.error',
+//   SocketMessage = 'signalwire.socket.message',
+
+//   // Internal events
+//   SpeedTest = 'signalwire.internal.speedtest',
+
+//   // Global Events
+//   Ready = 'signalwire.ready',
+//   Error = 'signalwire.error',
+//   Notification = 'signalwire.notification',
+
+//   // Blade Events
+//   Messages = 'signalwire.messages',
+//   Calls = 'signalwire.calls',
+
+//   // RTC Events
+//   MediaError = 'signalwire.rtc.mediaError',
+// }

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,0 +1,84 @@
+import { STORAGE_PREFIX } from './constants'
+
+export const deepCopy = (obj: Object) => JSON.parse(JSON.stringify(obj))
+
+export const mutateStorageKey = (key: string) => `${STORAGE_PREFIX}${key}`
+
+export const safeParseJson = (value: string): string | Object => {
+  if (typeof value !== 'string') {
+    return value
+  }
+  try {
+    return JSON.parse(value)
+  } catch (error) {
+    return value
+  }
+}
+
+const PROTOCOL_PATTERN = /^(ws|wss):\/\//
+export const checkWebSocketHost = (host: string): string => {
+  const protocol = PROTOCOL_PATTERN.test(host) ? '' : 'wss://'
+  return `${protocol}${host}`
+}
+
+/**
+ * From the socket we can get:
+ * - JSON-RPC msg with 1 level of 'result' or 'error'
+ * - JSON-RPC msg with 2 nested 'result' and 'code' property to identify error
+ * - JSON-RPC msg with 3 nested 'result' where the third level is the Verto JSON-RPC flat msg.
+ *
+ * @returns Object with error | result key to identify success or fail
+ */
+export const destructResponse = (
+  response: any,
+  nodeId: string = null
+): { [key: string]: any } => {
+  const { result = {}, error } = response
+  if (error) {
+    return { error }
+  }
+  const { result: nestedResult = null } = result
+  if (nestedResult === null) {
+    if (nodeId !== null) {
+      result.node_id = nodeId
+    }
+    return { result }
+  }
+  const {
+    code = null,
+    node_id = null,
+    result: vertoResult = null,
+  } = nestedResult
+  if (code && code !== '200') {
+    return { error: nestedResult }
+  }
+  if (vertoResult) {
+    return destructResponse(vertoResult, node_id)
+  }
+  if (code && node_id) {
+    return { result: nestedResult }
+  }
+  return { result }
+}
+
+export const randomInt = (min: number, max: number) => {
+  return Math.floor(Math.random() * (max - min + 1) + min)
+}
+
+export const roundToFixed = (value: number, num = 2) => {
+  return Number(value.toFixed(num))
+}
+
+export const timeoutPromise = (
+  promise: Promise<unknown>,
+  time: number,
+  exception: any
+) => {
+  let timer = null
+  return Promise.race([
+    promise,
+    new Promise(
+      (_resolve, reject) => (timer = setTimeout(reject, time, exception))
+    ),
+  ]).finally(() => clearTimeout(timer))
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,5 +1,8 @@
 import { STORAGE_PREFIX } from './constants'
 
+export { v4 as uuid } from 'uuid'
+export { logger } from './logger'
+
 export const deepCopy = (obj: Object) => JSON.parse(JSON.stringify(obj))
 
 export const mutateStorageKey = (key: string) => `${STORAGE_PREFIX}${key}`

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -31,7 +31,7 @@ export const checkWebSocketHost = (host: string): string => {
  */
 export const destructResponse = (
   response: any,
-  nodeId: string = null
+  nodeId?: string
 ): { [key: string]: any } => {
   const { result = {}, error } = response
   if (error) {
@@ -39,7 +39,7 @@ export const destructResponse = (
   }
   const { result: nestedResult = null } = result
   if (nestedResult === null) {
-    if (nodeId !== null) {
+    if (nodeId) {
       result.node_id = nodeId
     }
     return { result }
@@ -74,7 +74,7 @@ export const timeoutPromise = (
   time: number,
   exception: any
 ) => {
-  let timer = null
+  let timer: any = null
   return Promise.race([
     promise,
     new Promise(

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -1,0 +1,41 @@
+type JSONRPCParams = {
+  [key: string]: any
+}
+
+type JSONRPCResult = {
+  [key: string]: any
+}
+
+type JSONRPCError = {
+  [key: string]: any
+}
+
+export interface JSONRPCRequest {
+  jsonrpc: '2.0'
+  id: string
+  method: string
+  params?: JSONRPCParams
+}
+
+export interface JSONRPCResponse {
+  jsonrpc: '2.0'
+  id: string
+  result?: JSONRPCResult
+  error?: JSONRPCError
+}
+
+export interface SessionOptions {
+  host?: string
+  project: string
+  token: string
+}
+
+export interface SessionRequestObject {
+  resolve: (value: unknown) => void
+  reject: (value: unknown) => void
+}
+
+export interface SessionRequestQueued {
+  resolve: (value: unknown) => void
+  msg: JSONRPCRequest | JSONRPCResponse
+}

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -39,3 +39,12 @@ export interface SessionRequestQueued {
   resolve: (value: unknown) => void
   msg: JSONRPCRequest | JSONRPCResponse
 }
+
+export interface IBladeAuthorization {
+  expires_at: number
+  signature: string
+  project: string
+  scope_id: string
+  scopes: string[]
+  resource: string
+}

--- a/packages/core/src/utils/storage/index.native.ts
+++ b/packages/core/src/utils/storage/index.native.ts
@@ -1,6 +1,7 @@
+// @ts-nocheck
+
 // TODO: Review ReactNative support
 
-// @ts-ignore
 import AsyncStorage from '@react-native-community/async-storage'
 import { mutateStorageKey, safeParseJson } from '../'
 

--- a/packages/core/src/utils/storage/index.native.ts
+++ b/packages/core/src/utils/storage/index.native.ts
@@ -1,0 +1,27 @@
+// TODO: Review ReactNative support
+
+// @ts-ignore
+import AsyncStorage from '@react-native-community/async-storage'
+import { mutateStorageKey, safeParseJson } from '../'
+
+const getItem = async (key: string): Promise<any> => {
+  try {
+    const res = await AsyncStorage.getItem(mutateStorageKey(key))
+    return safeParseJson(res)
+  } catch (error) {
+    return null
+  }
+}
+
+const setItem = (key: string, value: any): Promise<void> => {
+  if (typeof value === 'object') {
+    value = JSON.stringify(value)
+  }
+  return AsyncStorage.setItem(mutateStorageKey(key), value)
+}
+
+const removeItem = (key: string): Promise<void> =>
+  AsyncStorage.removeItem(mutateStorageKey(key))
+
+export const localStorage = { getItem, setItem, removeItem }
+export const sessionStorage = { getItem, setItem, removeItem }

--- a/packages/core/src/utils/storage/index.ts
+++ b/packages/core/src/utils/storage/index.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { mutateStorageKey, safeParseJson } from '../'
 
 const _inNode = () =>

--- a/packages/core/src/utils/storage/index.ts
+++ b/packages/core/src/utils/storage/index.ts
@@ -1,0 +1,44 @@
+import { mutateStorageKey, safeParseJson } from '../'
+
+const _inNode = () =>
+  typeof window === 'undefined' && typeof process !== 'undefined'
+
+const _get = async (storageType: string, key: string): Promise<any> => {
+  if (_inNode()) return null
+
+  const res = window[storageType].getItem(mutateStorageKey(key))
+  return safeParseJson(res)
+}
+
+const _set = async (
+  storageType: string,
+  key: string,
+  value: any
+): Promise<void> => {
+  if (_inNode()) return null
+
+  if (typeof value === 'object') {
+    value = JSON.stringify(value)
+  }
+  window[storageType].setItem(mutateStorageKey(key), value)
+}
+
+const _remove = async (storageType: string, key: string): Promise<void> => {
+  if (_inNode()) return null
+
+  return window[storageType].removeItem(mutateStorageKey(key))
+}
+
+export const localStorage = {
+  getItem: (key: string): Promise<any> => _get('localStorage', key),
+  setItem: (key: string, value: any): Promise<void> =>
+    _set('localStorage', key, value),
+  removeItem: (key: string): Promise<void> => _remove('localStorage', key),
+}
+
+export const sessionStorage = {
+  getItem: (key: string): Promise<any> => _get('sessionStorage', key),
+  setItem: (key: string, value: any): Promise<void> =>
+    _set('sessionStorage', key, value),
+  removeItem: (key: string): Promise<void> => _remove('sessionStorage', key),
+}

--- a/packages/web/examples/src/main.tsx
+++ b/packages/web/examples/src/main.tsx
@@ -2,6 +2,19 @@
 // `production` bundle while importing from `../../src` will
 // hot-reload as we make changes.
 
-import { sum } from '../../src'
+import { JWTSession } from '../../src'
 
-console.log(sum(1, 3))
+// @ts-ignore
+window._makeClient = ({ project, token }) => {
+  const client = new JWTSession({
+    host: 'relay.swire.io',
+    project,
+    token,
+  })
+
+  client.connect()
+
+  // @ts-ignore
+  window.__client = client
+  return client
+}

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -1,4 +1,4 @@
-import { uuid, logger } from '@signalwire/core'
+import { uuid, logger, JWTSession } from '@signalwire/core'
 import * as webrtc from '@signalwire/webrtc'
 
 export const sum = (a: number, b: number) => {
@@ -9,3 +9,5 @@ export const sum = (a: number, b: number) => {
 
   return a + b
 }
+
+export { JWTSession }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -24,7 +24,8 @@
       "@signalwire/node": ["packages/node/src"]
     },
     "composite": true,
-    "declarationMap": true
+    "declarationMap": true,
+    "strictPropertyInitialization": false
   },
   "include": ["packages"]
 }


### PR DESCRIPTION
This PR includes the initial SDK objects to connect a base client.

To run the example you need: 

- Build the packages and then `npm run start:web` as normal
- Generate JWT with the curl requests we saw before (using project and token)
- Then run from the console on `localhost:3000`:
    ```js
    _makeClient({ project: '<PROJECT>', token: '<JWT>' })
    ```

It creates a `window.__client` instance we can inspect and play with - we'll make a nice demo too  👍 