### PR TITLE
Check missing blade.ping from backend

### DIFF
--- a/packages/core/src/JWTSession.ts
+++ b/packages/core/src/JWTSession.ts
@@ -17,7 +17,7 @@ export class JWTSession extends Session {
   /**
    * Check the JWT expiration every 20seconds
    */
-  private _checkTokenExpirationDelay = 20
+  private _checkTokenExpirationDelay = 20 * 1000
   private _checkTokenExpirationTimer: any = null
 
   constructor(public options: SessionOptions) {


### PR DESCRIPTION
Every ping start a timer to wait for the next - to detect half-open conditions and force-close the connection from the client