### PR TITLE
Basic test for JWTSession + minor fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8806,6 +8806,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/jest-websocket-mock": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/jest-websocket-mock/-/jest-websocket-mock-2.2.0.tgz",
+      "integrity": "sha512-lc3wwXOEyNa4ZpcgJtUG3mmKMAq5FAsKYiZph0p/+PAJrAPuX4JCIfJMdJ/urRsLBG51fwm/wlVPNbR6s2nzNw==",
+      "dev": true,
+      "peerDependencies": {
+        "mock-socket": "^8||^9"
+      }
+    },
     "node_modules/jest-worker": {
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.5.0.tgz",
@@ -9517,6 +9526,18 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mock-socket": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.0.3.tgz",
+      "integrity": "sha512-SxIiD2yE/By79p3cNAAXyLQWTvEFNEzcAO7PH+DzRqKSFaplAPFjiQLmw8ofmpCsZf+Rhfn2/xCJagpdGmYdTw==",
+      "dev": true,
+      "dependencies": {
+        "url-parse": "^1.4.4"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/mri": {
@@ -10453,6 +10474,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -10829,6 +10856,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "dev": true
     },
     "node_modules/resolve": {
       "version": "1.20.0",
@@ -12962,6 +12995,16 @@
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
     },
+    "node_modules/url-parse": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
+      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
+      "dev": true,
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/url-parse-lax": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
@@ -13421,7 +13464,9 @@
         "uuid": "^8.3.2"
       },
       "devDependencies": {
-        "@types/uuid": "^8.3.0"
+        "@types/uuid": "^8.3.0",
+        "jest-websocket-mock": "^2.2.0",
+        "mock-socket": "^9.0.3"
       },
       "engines": {
         "node": ">=10"
@@ -15372,7 +15417,9 @@
       "version": "file:packages/core",
       "requires": {
         "@types/uuid": "^8.3.0",
+        "jest-websocket-mock": "^2.2.0",
         "loglevel": "^1.7.1",
+        "mock-socket": "^9.0.3",
         "uuid": "^8.3.2"
       },
       "dependencies": {
@@ -20260,6 +20307,13 @@
         }
       }
     },
+    "jest-websocket-mock": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/jest-websocket-mock/-/jest-websocket-mock-2.2.0.tgz",
+      "integrity": "sha512-lc3wwXOEyNa4ZpcgJtUG3mmKMAq5FAsKYiZph0p/+PAJrAPuX4JCIfJMdJ/urRsLBG51fwm/wlVPNbR6s2nzNw==",
+      "dev": true,
+      "requires": {}
+    },
     "jest-worker": {
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.5.0.tgz",
@@ -20816,6 +20870,15 @@
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
         "minimist": "^1.2.5"
+      }
+    },
+    "mock-socket": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.0.3.tgz",
+      "integrity": "sha512-SxIiD2yE/By79p3cNAAXyLQWTvEFNEzcAO7PH+DzRqKSFaplAPFjiQLmw8ofmpCsZf+Rhfn2/xCJagpdGmYdTw==",
+      "dev": true,
+      "requires": {
+        "url-parse": "^1.4.4"
       }
     },
     "mri": {
@@ -21520,6 +21583,12 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
+    "querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
+    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -21811,6 +21880,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "dev": true
     },
     "resolve": {
       "version": "1.20.0",
@@ -23480,6 +23555,16 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+    },
+    "url-parse": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
+      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
+      "dev": true,
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
     },
     "url-parse-lax": {
       "version": "3.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,6 +23,8 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@types/uuid": "^8.3.0"
+    "@types/uuid": "^8.3.0",
+    "jest-websocket-mock": "^2.2.0",
+    "mock-socket": "^9.0.3"
   }
 }

--- a/packages/core/src/JWTSession.test.ts
+++ b/packages/core/src/JWTSession.test.ts
@@ -1,0 +1,33 @@
+import WS from 'jest-websocket-mock'
+
+import { JWTSession } from './JWTSession'
+
+const HOST = 'ws://localhost:8080'
+
+let ws: WS
+beforeEach(() => {
+  ws = new WS(HOST)
+})
+afterEach(() => {
+  WS.clean()
+})
+
+describe('JWTSession', () => {
+  it('should connect connect and disconnect to/from the provided host', async () => {
+    const client = new JWTSession({
+      host: HOST,
+      project: 'asd',
+      token: 'sometoken',
+    })
+
+    client.connect()
+    await ws.connected
+
+    expect(client.connected).toBe(true)
+
+    client.disconnect()
+
+    expect(client.connected).toBe(false)
+    expect(client.closed).toBe(true)
+  })
+})

--- a/packages/core/src/Session.ts
+++ b/packages/core/src/Session.ts
@@ -80,7 +80,9 @@ export class Session {
   }
 
   get closed() {
-    return this._socket?.readyState === WebSocketState.CLOSED
+    return this._socket
+      ? this._socket.readyState === WebSocketState.CLOSED
+      : true
   }
 
   /**

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -6,6 +6,7 @@
     "declaration": true,
     "sourceMap": true,
     "strict": true,
+    "target": "ES2015",
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
The code in this changeset includes:

* Added `jest-websocket-mock` to mock WS when running tests
* Basic test for `connect/disconnect` events when using `JWTSession`
* Minor change on how `Session.closed` works since `disconnect` is removing the instance right after closing the connection .