### PR TITLE
Add option to Unsubscribe from the store

### DIFF
--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -3,11 +3,20 @@ import { uuid } from './utils'
 export class BaseComponent {
   id = uuid()
   _requests = new Map()
+  private _destroyer?: () => void
 
   constructor(public options: any) {}
 
+  set destroyer(d: () => void) {
+    this._destroyer = d
+  }
+
   get store() {
     return this.options.store
+  }
+
+  destroy() {
+    this._destroyer?.()
   }
 
   execute(msg: any) {

--- a/packages/core/src/redux/utils.ts
+++ b/packages/core/src/redux/utils.ts
@@ -1,12 +1,23 @@
-export const connect = (options: any) => {
+import { Store } from "redux";
+import { ComponentState } from "./interfaces"
+import { BaseComponent } from "../BaseComponent";
+
+type ConnectEventHandler = (state: ComponentState) => any;
+interface Connect<T extends typeof BaseComponent> {
+  onStateChangeListeners: Record<string, string | ConnectEventHandler>;
+  store: Store;
+  Component: T
+}
+
+export const connect = <T extends typeof BaseComponent>(options: Connect<T>) => {
   const { onStateChangeListeners = {}, store, Component } = options
   const componentKeys = Object.keys(onStateChangeListeners)
 
   return (userOptions: any) => {
     const instance = new Component({ ...userOptions, store })
     const cacheMap = new Map<string, any>()
-    // const _unsubscribe = store.subscribe(() => {
-    store.subscribe(() => {
+
+    const storeUnsubscribe = store.subscribe(() => {
       const { components = {} } = store.getState()
       componentKeys.forEach((key) => {
         const current = cacheMap.get(key)
@@ -14,13 +25,20 @@ export const connect = (options: any) => {
         if (updatedValue !== undefined && current !== updatedValue) {
           cacheMap.set(key, updatedValue)
           const fnName = onStateChangeListeners[key]
-          instance[fnName](components[instance.id])
+
+          if (typeof fnName === "string") {
+            instance[fnName](components[instance.id])
+          } else {
+            fnName(components[instance.id])
+          }
         }
       })
     })
 
-    // TODO: automatically attach unsubscribe to the object destroy
-    // TODO: remove instance.id from cacheMap
+    instance.destroyer = () => {
+      storeUnsubscribe();
+      cacheMap.clear()
+    }
 
     return instance
   }


### PR DESCRIPTION
The code in this changeset includes a tentative API for unsubscribing from the store (and cleaning the cache) when calling the `instance.destroy()` method.

Also, I've extended the `connect` with a couple of things:
* Added typings for its options
* Added option to pass handlers (on top of regular strings) to each state prop