### PR TITLE
Add option to validate the `emitter` at runtime + code cleanup

### DIFF
--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -10,13 +10,6 @@ export class BaseComponent implements Emitter {
 
   constructor(public options: any) {}
 
-  // TODO: make sure emitter is defined here
-  on = this.options.emitter.on
-  off = this.options.emitter.off
-  once = this.options.emitter.once
-  removeAllListeners = this.options.emitter.removeAllListeners
-  emit = this.options.emitter.emit
-
   set destroyer(d: () => void) {
     this._destroyer = d
   }
@@ -24,6 +17,16 @@ export class BaseComponent implements Emitter {
   get store() {
     return this.options.store
   }
+
+  get emitter() {
+    return this.options.emitter
+  }
+
+  on = this.emitter.on
+  off = this.emitter.off
+  once = this.emitter.once
+  removeAllListeners = this.emitter.removeAllListeners
+  emit = this.emitter.emit
 
   destroy() {
     this._destroyer?.()

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,7 +4,7 @@ import { JWTSession } from './JWTSession'
 import { configureStore, connect } from './redux'
 import { SignalWire } from './SignalWire'
 import { BaseComponent } from './BaseComponent'
-import { EventPubSub } from './utils/PubSub'
+import { EventEmitter, getEventEmitter } from './utils/EventEmitter'
 
 // prettier-ignore
 export {
@@ -16,7 +16,8 @@ export {
   SignalWire,
   connect,
   configureStore,
-  EventPubSub
+  EventEmitter,
+  getEventEmitter
 }
 
 export * from './RPCMessages'

--- a/packages/core/src/redux/index.ts
+++ b/packages/core/src/redux/index.ts
@@ -44,7 +44,6 @@ const configureStore = (options: ConfigureStoreOptions) => {
       // different root sagas
       sagas,
     })
-    // TODO: update arguments.
     sagaMiddleware.run(saga, userOptions)
   }
 

--- a/packages/core/src/redux/rootSaga.ts
+++ b/packages/core/src/redux/rootSaga.ts
@@ -23,15 +23,12 @@ export default (
     ? options.sagas(getDefaultSagas)
     : getDefaultSagas()
 
-  // TODO: update parameter: This should accept an interface similar
-  // to what we're sending to configureStore
   return function* root(userOptions: UserOptions) {
     const pubSubChannel = yield call(channel)
 
     yield spawn(pubSubSaga, {
       pubSubChannel,
       emitter: userOptions.emitter,
-      // TODO: pass pubSubInstance
     })
 
     /**

--- a/packages/core/src/utils/EventEmitter.test.ts
+++ b/packages/core/src/utils/EventEmitter.test.ts
@@ -1,7 +1,7 @@
 import { Emitter } from './interfaces'
-import { EventPubSub } from './PubSub'
+import { EventEmitter } from './EventEmitter'
 
-describe('EventPubSub Class', () => {
+describe('EventEmitter Class', () => {
   let instance: Emitter
   const exampleData = {
     test: 'data',
@@ -10,7 +10,7 @@ describe('EventPubSub Class', () => {
   const eventName = 'event'
 
   beforeEach(() => {
-    instance = EventPubSub()
+    instance = EventEmitter()
   })
 
   describe('.on() method', () => {

--- a/packages/core/src/utils/EventEmitter.ts
+++ b/packages/core/src/utils/EventEmitter.ts
@@ -1,9 +1,9 @@
-import { Emitter } from './interfaces'
+import { Emitter, UserOptions } from './interfaces'
 
-export const EventPubSub = () => {
+export const EventEmitter = () => {
   const _queue: { [key: string]: Function[] } = {}
   const _uniqueKey = Symbol.for('sw-once-key')
-  return new (class BaseEventPubSub implements Emitter<BaseEventPubSub> {
+  return new (class BaseEventEmitter implements Emitter<BaseEventEmitter> {
     on(eventName: string, handler: Function, once = false) {
       if (!_queue[eventName]) {
         _queue[eventName] = []
@@ -66,4 +66,43 @@ export const EventPubSub = () => {
       return this
     }
   })()
+}
+
+const REQUIRED_EMITTER_METHODS = [
+  'on',
+  'off',
+  'once',
+  'removeAllListeners',
+  'emit',
+]
+
+/**
+ * Checks the shape of the emitter at runtime. This is useful for when
+ * the user is using the SDK without TS
+ */
+export const assertEventEmitter = (emitter: unknown): emitter is Emitter => {
+  if (
+    emitter &&
+    typeof emitter === 'object' &&
+    REQUIRED_EMITTER_METHODS.every((name) => name in emitter)
+  ) {
+    return true
+  }
+
+  return false
+}
+
+export const getEventEmitter = (userOptions: UserOptions): Emitter => {
+  if (!userOptions.emitter) {
+    return EventEmitter()
+  } else if (assertEventEmitter(userOptions.emitter)) {
+    return userOptions.emitter
+  }
+
+  // TODO: In future versions we can narrow this error a bit more and
+  // give the user more info about which method they are missing as
+  // well
+  throw new Error(
+    "The passed `emitter` doesn't expose the correct interface. Please check that your custom `emitter` comply with the `Emitter` interface."
+  )
 }

--- a/packages/web/examples/ts-vanilla/index.ts
+++ b/packages/web/examples/ts-vanilla/index.ts
@@ -5,7 +5,7 @@
 import { createSession } from '../../src'
 
 // @ts-ignore
-window._makeClient = async ({ project, token }) => {
+window._makeClient = async ({ project, token, emitter }) => {
   const client = await createSession({
     host: 'relay.swire.io',
     project,
@@ -14,6 +14,7 @@ window._makeClient = async ({ project, token }) => {
     onReady: async () => {
       console.debug('Session Ready')
     },
+    emitter,
   })
 
   // @ts-ignore

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -4,7 +4,7 @@ import {
   configureStore,
   connect,
   UserOptions,
-  EventPubSub,
+  getEventEmitter,
 } from '@signalwire/core'
 import { Call } from '@signalwire/webrtc'
 
@@ -37,7 +37,7 @@ export const createSession = (userOptions: UserOptions): Promise<Client> => {
   return new Promise((resolve, _reject) => {
     const baseUserOptions: UserOptions = {
       ...userOptions,
-      emitter: userOptions.emitter || EventPubSub(),
+      emitter: getEventEmitter(userOptions),
     }
     const store = configureStore({ userOptions: baseUserOptions })
     const client = new Client(baseUserOptions, store)


### PR DESCRIPTION
The code in this changeset includes:

* Added option to validate the `emitter` option (from `userOptions`) at runtime. When the user provides an `emitter` that doesn't comply with our expected interface we fail immediately (since this check happens at the very beginning of the process ) by throwing an error with a description of what they are missing.
* Fixes for #35 