### PR TITLE
Remove __store on Window

### DIFF
--- a/packages/core/src/redux/index.ts
+++ b/packages/core/src/redux/index.ts
@@ -35,9 +35,6 @@ const configureStore = (options: ConfigureStoreOptions) => {
       getDefaultMiddleware().concat(sagaMiddleware),
   })
 
-  // @ts-ignore
-  window['__store'] = store
-
   if (runSagaMiddleware) {
     const saga = rootSaga({
       // In here the consumer will have the option to setup


### PR DESCRIPTION
If we need it during debug we can access it from the `client.store`