### PR TITLE
Session Slice

### DIFF
--- a/packages/core/src/JWTSession.ts
+++ b/packages/core/src/JWTSession.ts
@@ -44,7 +44,7 @@ export class JWTSession extends Session {
   }
 
   get expiresAt() {
-    return this?._authorization?.expires_at ?? 0
+    return this?._bladeConnectResult?.authorization?.expires_at ?? 0
   }
 
   get expiresIn() {
@@ -82,13 +82,10 @@ export class JWTSession extends Session {
         }
       }
 
-      const response = await this.execute(BladeConnect(params))
-      this._authorization = response.authorization
-      this.relayProtocol = response?.result?.protocol ?? ''
+      this._bladeConnectResult = await this.execute(BladeConnect(params))
       this._checkTokenExpiration()
-      console.log('Response', response)
-      // TODO: check JWT expires_at and handle re-auth
     } catch (error) {
+      // FIXME: Handle Auth Error
       console.error('Auth Error', error)
     }
   }
@@ -105,6 +102,7 @@ export class JWTSession extends Session {
       logger.debug(
         'Your JWT is going to expire. Please refresh it to keep the session live.'
       )
+      // TODO: check JWT expires_at and handle re-auth
       // trigger(SwEvent.Notification, { type: Notification.RefreshToken, session: this }, this.uuid, false)
     }
     clearTimeout(this._checkTokenExpirationTimer)

--- a/packages/core/src/Session.ts
+++ b/packages/core/src/Session.ts
@@ -60,6 +60,10 @@ export class Session {
     this.logger.setLevel(this.logger.levels.INFO)
   }
 
+  get bladeConnectResult() {
+    return this._bladeConnectResult
+  }
+
   get relayProtocol() {
     return this._bladeConnectResult?.result?.protocol ?? ''
   }

--- a/packages/core/src/Session.ts
+++ b/packages/core/src/Session.ts
@@ -134,6 +134,7 @@ export class Session {
     }
 
     this._socket.close()
+    // @ts-ignore
     delete this._socket
     // clearTimeout(this._reconnectTimeout)
     // this.subscriptions.clear()

--- a/packages/core/src/Session.ts
+++ b/packages/core/src/Session.ts
@@ -10,7 +10,7 @@ import {
   SessionOptions,
   SessionRequestObject,
   SessionRequestQueued,
-  IBladeAuthorization,
+  IBladeConnectResult,
   JSONRPCRequest,
   JSONRPCResponse,
 } from './utils/interfaces'
@@ -24,11 +24,10 @@ import {
 
 export class Session {
   public uuid = uuid()
-  public relayProtocol = ''
   public sessionid = ''
   public WebSocketConstructor: typeof WebSocket
 
-  protected _authorization: IBladeAuthorization
+  protected _bladeConnectResult: IBladeConnectResult
 
   private _requests = new Map<string, SessionRequestObject>()
   private _requestQueue: SessionRequestQueued[] = []
@@ -61,8 +60,12 @@ export class Session {
     this.logger.setLevel(this.logger.levels.INFO)
   }
 
+  get relayProtocol() {
+    return this._bladeConnectResult?.result?.protocol ?? ''
+  }
+
   get signature() {
-    return this?._authorization?.signature
+    return this._bladeConnectResult?.authorization?.signature
   }
 
   get logger(): typeof logger {
@@ -201,11 +204,9 @@ export class Session {
         params.params = params.params || {}
         params.params.protocol = this.relayProtocol
       }
-      const response = await this.execute(BladeConnect(params))
-      console.log('Response', response)
-      this._authorization = response.authorization
-      this.relayProtocol = response?.result?.protocol ?? ''
+      this._bladeConnectResult = await this.execute(BladeConnect(params))
     } catch (error) {
+      // FIXME: Handle Auth Error
       console.error('Auth Error', error)
     }
   }

--- a/packages/core/src/redux/features/index.ts
+++ b/packages/core/src/redux/features/index.ts
@@ -1,1 +1,2 @@
 export * from './component/componentSlice'
+export * from './session/sessionSlice'

--- a/packages/core/src/redux/features/session/sessionSlice.test.ts
+++ b/packages/core/src/redux/features/session/sessionSlice.test.ts
@@ -1,0 +1,28 @@
+import { Store } from 'redux'
+import { configureJestStore, bladeConnectResultVRT } from '../../../testUtils'
+import { sessionActions, initialSessionState } from './sessionSlice'
+import { destroyAction } from '../../actions'
+
+describe('SessionState Tests', () => {
+  let store: Store
+
+  beforeEach(() => {
+    store = configureJestStore()
+  })
+
+  it('should listen calls/destroy actions and save the history', () => {
+    store.dispatch(sessionActions.connected(bladeConnectResultVRT))
+
+    expect(store.getState().session).toStrictEqual({
+      protocol: bladeConnectResultVRT.result?.protocol,
+      iceServers: bladeConnectResultVRT.result?.iceServers,
+    })
+  })
+
+  it('should reset to initial on destroyAction', () => {
+    store.dispatch(sessionActions.connected(bladeConnectResultVRT))
+
+    store.dispatch(destroyAction())
+    expect(store.getState().session).toStrictEqual(initialSessionState)
+  })
+})

--- a/packages/core/src/redux/features/session/sessionSlice.test.ts
+++ b/packages/core/src/redux/features/session/sessionSlice.test.ts
@@ -10,7 +10,7 @@ describe('SessionState Tests', () => {
     store = configureJestStore()
   })
 
-  it('should listen calls/destroy actions and save the history', () => {
+  it('should seed SessionState on sessionActions.connected action', () => {
     store.dispatch(sessionActions.connected(bladeConnectResultVRT))
 
     expect(store.getState().session).toStrictEqual({

--- a/packages/core/src/redux/features/session/sessionSlice.ts
+++ b/packages/core/src/redux/features/session/sessionSlice.ts
@@ -1,0 +1,31 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { SessionState } from '../../interfaces'
+import { IBladeConnectResult } from '../../../utils/interfaces'
+import { destroyAction } from '../../actions'
+
+export const initialSessionState: Readonly<SessionState> = {
+  protocol: '',
+  iceServers: [],
+}
+
+const sessionSlice = createSlice({
+  name: 'session',
+  initialState: initialSessionState,
+  reducers: {
+    connected: (state, { payload }: PayloadAction<IBladeConnectResult>) => {
+      state.protocol = payload?.result?.protocol ?? ''
+      state.iceServers = payload?.result?.iceServers ?? []
+    },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(destroyAction.type, () => {
+      return initialSessionState
+    })
+  },
+})
+
+// prettier-ignore
+export const {
+  actions: sessionActions,
+  reducer: sessionReducer
+} = sessionSlice

--- a/packages/core/src/redux/interfaces.ts
+++ b/packages/core/src/redux/interfaces.ts
@@ -30,8 +30,14 @@ export interface ComponentState {
   [key: string]: ReduxComponent
 }
 
+export interface SessionState {
+  protocol: string
+  iceServers?: RTCIceServer[]
+}
+
 export interface SDKState {
   components: ComponentState
+  session: SessionState
 }
 
 export type GetDefaultSagas = () => Saga[]

--- a/packages/core/src/redux/rootReducer.ts
+++ b/packages/core/src/redux/rootReducer.ts
@@ -1,6 +1,7 @@
 import { combineReducers } from '@reduxjs/toolkit'
-import { componentReducer } from './features'
+import { componentReducer, sessionReducer } from './features'
 
 export const rootReducer = combineReducers({
   components: componentReducer,
+  session: sessionReducer,
 })

--- a/packages/core/src/redux/rootSaga.ts
+++ b/packages/core/src/redux/rootSaga.ts
@@ -1,6 +1,6 @@
 import { Saga, Task, SagaIterator, Channel } from '@redux-saga/types'
 import { channel, EventChannel } from 'redux-saga'
-import { all, spawn, fork, call, take } from 'redux-saga/effects'
+import { all, spawn, fork, call, take, put } from 'redux-saga/effects'
 import { GetDefaultSagas } from './interfaces'
 import { UserOptions, SessionConstructor } from '../utils/interfaces'
 import {
@@ -11,6 +11,8 @@ import {
 import { pubSubSaga } from './features/pubSub/pubSubSaga'
 import { logger } from '../utils'
 import { initAction, destroyAction } from './actions'
+import { sessionActions } from './features'
+import { Session } from '..'
 
 // prettier-ignore
 const ROOT_SAGAS: Saga[] = []
@@ -58,7 +60,7 @@ export default (options: RootSagaOptions) => {
      * Create Session and related sessionChannel to
      * send/receive websocket messages
      */
-    const session = yield call(
+    const session: Session = yield call(
       initSession,
       options.SessionConstructor,
       userOptions
@@ -67,6 +69,7 @@ export default (options: RootSagaOptions) => {
       createSessionChannel,
       session
     )
+    yield put(sessionActions.connected(session.bladeConnectResult))
 
     /**
      * Create a channel to communicate between sagas

--- a/packages/core/src/testUtils.ts
+++ b/packages/core/src/testUtils.ts
@@ -1,0 +1,60 @@
+import { configureStore } from './redux'
+import { Session } from './Session'
+import { IBladeConnectResult } from './utils/interfaces'
+
+const PROJECT_ID = '8f0a119a-cda7-4497-a47d-c81493b824d4'
+const TOKEN = '<VRT>'
+
+/**
+ * Helper method to configure a Store w/o Saga middleware.
+ * Useful to test slices and reducers logic.
+ *
+ * @returns Redux Store
+ */
+export const configureJestStore = () => {
+  return configureStore({
+    userOptions: {
+      project: PROJECT_ID,
+      token: TOKEN,
+      devTools: false,
+    },
+    SessionConstructor: Session,
+    runSagaMiddleware: false,
+  })
+}
+
+export const bladeConnectResultVRT: IBladeConnectResult = {
+  session_restored: false,
+  sessionid: 'd9821036-30d4-4e22-82eb-f6f1dac36d21',
+  nodeid:
+    'f3bc99df-2c3d-4fa4-b1dc-e8a8ffc579e6@e3fefa44-1bad-4be9-ad9b-1cbb9abd60c7.west-us',
+  identity:
+    'f3bc99df-2c3d-4fa4-b1dc-e8a8ffc579e6@e3fefa44-1bad-4be9-ad9b-1cbb9abd60c7.west-us',
+  master_nodeid: '00000000-0000-0000-0000-000000000000@',
+  authorization: {
+    type: 'video',
+    project: '8f0a119a-cda7-4497-a47d-c81493b824d4',
+    scopes: ['video'],
+    scope_id: '26675883-8499-4ee9-85eb-691c4aa209f8',
+    resource: '9c80f1e8-9430-4070-a043-937eb3a96b38',
+    user_name: 'Joe',
+    room: {
+      name: 'lobby',
+      scopes: ['conference.self.audio_mute', 'conference.self.audio_unmute'],
+    },
+    signature:
+      'SGZtkRD9fvuBAOUp1UF56zESxdEvGT6qSGZtkRD9fvuBAOUp1UF56zESxdEvGT6q',
+  },
+  result: {
+    protocol:
+      'signalwire_SGZtkRD9fvuBAOUp1UF56zESxdEvGT6qSGZtkRD9fvuBAOUp1UF56zESxdEvGT6q_03e8c927-8ea3-4661-86d5-778c3e03296a_8f0a119a-cda7-4497-a47d-c81493b824d4',
+    iceServers: [
+      {
+        urls: 'turn.swire.io:443',
+        credential: 'sFTwvi8ShXcYNOcyYjFy3ATIUpQ=',
+        credentialType: 'password',
+        username: '1619521908:8f0a119a-cda7-4497-a47d-c81493b824d4',
+      },
+    ],
+  },
+}

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -59,12 +59,31 @@ export interface SessionRequestQueued {
 }
 
 export interface IBladeAuthorization {
-  expires_at: number
-  signature: string
+  type: 'video'
   project: string
-  scope_id: string
   scopes: string[]
+  scope_id: string
   resource: string
+  user_name: string
+  room?: {
+    name: string
+    scopes: string[]
+  }
+  signature: string
+  expires_at?: number
+}
+
+export interface IBladeConnectResult {
+  session_restored: boolean
+  sessionid: string
+  nodeid: string
+  identity: string
+  master_nodeid: string
+  authorization: IBladeAuthorization
+  result?: {
+    protocol: string
+    iceServers?: RTCIceServer[]
+  }
 }
 
 export type SessionConstructor = typeof Session


### PR DESCRIPTION
This PR add the `SessionState` in redux with its own `sessionSlice`. For now it holds only:

- protocol: protocol used to send/receive events over the wire
- iceServers: array of RTCIceServer used in WebRTC

In the future we may want to pick some other data from the BladeConnectResult object (ie: sessionid, scope_id, scopes... etc).

In another PR i'll add a `select`/`selector` method into BaseComponent so they can pass a selector function and grab whatever they need from the store. (Kind of the same of the `useSelector` hook)