### PR TITLE
Add "select" method to BaseComponent

### DIFF
--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -1,6 +1,7 @@
 import { uuid } from './utils'
 import { executeAction } from './redux'
 import { Emitter } from './utils/interfaces'
+import { SDKState } from './redux/interfaces'
 
 export class BaseComponent implements Emitter {
   id = uuid()
@@ -46,6 +47,10 @@ export class BaseComponent implements Emitter {
         })
       )
     })
+  }
+
+  select(selectorFn: (state: SDKState) => unknown) {
+    return selectorFn(this.store.getState())
   }
 
   onError(component: any) {

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -49,7 +49,7 @@ export class BaseComponent implements Emitter {
     })
   }
 
-  select(selectorFn: (state: SDKState) => unknown) {
+  select <T>(selectorFn: (state: SDKState) => T) {
     return selectorFn(this.store.getState())
   }
 


### PR DESCRIPTION
Following https://github.com/signalwire/video-sdk-poc/pull/50 , we now have a `select` function so every component can use selectors if/when they need to grab stuff from redux state.