### PR TITLE
Add Node examples + package setup for Node and Core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,14 @@
   "version": "0.0.0",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "exports": "./dist/index.modern.js",
+  "esmodule": "./dist/index.modern.mjs",
+  "type": "commonjs",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "default": "./dist/index.modern.mjs"
+    }
+  },
   "module": "dist/index.esm.js",
   "types": "dist/core/src/index.d.ts",
   "files": [

--- a/packages/node/examples/vanilla-esm/index.js
+++ b/packages/node/examples/vanilla-esm/index.js
@@ -1,0 +1,3 @@
+import * as sdkNode from '@signalwire/node'
+
+console.log('@signalwire/node', sdkNode)

--- a/packages/node/examples/vanilla-esm/package.json
+++ b/packages/node/examples/vanilla-esm/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "vanilla-esm",
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "node index.js"
+  }
+}

--- a/packages/node/examples/vanilla/index.js
+++ b/packages/node/examples/vanilla/index.js
@@ -1,0 +1,3 @@
+const sdkNode = require('@signalwire/node')
+
+console.log('@signalwire/node', sdkNode)

--- a/packages/node/examples/vanilla/package.json
+++ b/packages/node/examples/vanilla/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "vanilla",
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "node index.js"
+  }
+}

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -3,9 +3,16 @@
   "version": "0.0.0",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "exports": "./dist/index.modern.js",
   "module": "dist/index.esm.js",
   "types": "dist/node/src/index.d.ts",
+  "esmodule": "./dist/index.modern.mjs",
+  "type": "commonjs",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "default": "./dist/index.modern.mjs"
+    }
+  },
   "files": [
     "dist",
     "src"

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,5 +1,7 @@
 import { uuid, logger } from '@signalwire/core'
 
+export * from '@signalwire/core'
+
 export const sum = (a: number, b: number) => {
   if ('development' === process.env.NODE_ENV) {
     logger.info('Core feature', uuid())


### PR DESCRIPTION
The code in this changeset includes:

* Ability to use `@signalwire/core` and `@signalwire/node` from both, commonjs and esm environments
* Basic examples showing how to consume `@signalwire/node`