### PR TITLE
CLI for handling Package Typings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "hasInstallScript": true,
       "workspaces": [
         "./packages/*",
-        "./examples/*"
+        "./examples/*",
+        "./scripts/*"
       ],
       "dependencies": {
         "@babel/core": "^7.13.16",
@@ -2824,6 +2825,10 @@
       "dependencies": {
         "type-detect": "4.0.8"
       }
+    },
+    "node_modules/@sw-internal/pkg-typings": {
+      "resolved": "scripts/pkg-typings",
+      "link": true
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "1.1.2",
@@ -16919,6 +16924,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "scripts/pkg-typings": {
+      "version": "0.0.0",
+      "bin": {
+        "pkg-typings": "bin/cli.js"
+      }
     }
   },
   "dependencies": {
@@ -19157,6 +19168,9 @@
       "requires": {
         "type-detect": "4.0.8"
       }
+    },
+    "@sw-internal/pkg-typings": {
+      "version": "file:scripts/pkg-typings"
     },
     "@szmarczak/http-timer": {
       "version": "1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16926,6 +16926,7 @@
       }
     },
     "scripts/pkg-typings": {
+      "name": "@sw-internal/pkg-typings",
       "version": "0.0.0",
       "bin": {
         "pkg-typings": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "workspaces": [
     "./packages/*",
-    "./examples/*"
+    "./examples/*",
+    "./scripts/*"
   ],
   "scripts": {
     "postinstall": "manypkg check",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,6 @@
     }
   },
   "module": "dist/index.esm.js",
-  "types": "dist/core/src/index.d.ts",
   "files": [
     "dist",
     "src"
@@ -23,7 +22,7 @@
   },
   "scripts": {
     "start": "microbundle watch -f modern --tsconfig tsconfig.build.json",
-    "build": "microbundle --external none -f modern,es,cjs --define process.env.NODE_ENV=production --tsconfig ./tsconfig.build.json --target node",
+    "build": "pkg-typings --pre-run && microbundle --external none -f modern,es,cjs --define process.env.NODE_ENV=production --tsconfig ./tsconfig.build.json --target node && pkg-typings --after-run",
     "test": "NODE_ENV=test jest",
     "prepare": "npm run build"
   },
@@ -37,5 +36,6 @@
     "@types/uuid": "^8.3.0",
     "jest-websocket-mock": "^2.2.0",
     "mock-socket": "^9.0.3"
-  }
+  },
+  "types": "dist/core/src/index.d.ts"
 }

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -4,7 +4,6 @@
   "source": "src/index.ts",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
-  "types": "dist/node/src/index.d.ts",
   "esmodule": "./dist/index.modern.mjs",
   "type": "commonjs",
   "exports": {
@@ -22,11 +21,12 @@
   },
   "scripts": {
     "start": "microbundle watch -f modern --tsconfig tsconfig.build.json",
-    "build": "microbundle --external none -f modern,es,cjs --define process.env.NODE_ENV=production --tsconfig ./tsconfig.build.json --target node",
+    "build": "pkg-typings --pre-run && microbundle --external none -f modern,es,cjs --define process.env.NODE_ENV=production --tsconfig ./tsconfig.build.json --target node && pkg-typings --after-run",
     "test": "NODE_ENV=test jest",
     "prepare": "npm run build"
   },
   "dependencies": {
     "@signalwire/core": "0.0.0"
-  }
+  },
+  "types": "dist/node/src/index.d.ts"
 }

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -5,7 +5,6 @@
   "main": "dist/index.js",
   "exports": "./dist/index.modern.js",
   "module": "dist/index.esm.js",
-  "types": "dist/react-native/src/index.d.ts",
   "files": [
     "dist",
     "src"
@@ -15,7 +14,7 @@
   },
   "scripts": {
     "start": "microbundle watch -f modern --tsconfig tsconfig.build.json",
-    "build": "microbundle --external none -f modern,es,cjs --define process.env.NODE_ENV=production --tsconfig ./tsconfig.build.json --target node",
+    "build": "pkg-typings --pre-run && microbundle --external none -f modern,es,cjs --define process.env.NODE_ENV=production --tsconfig ./tsconfig.build.json --target node && pkg-typings --after-run",
     "test": "NODE_ENV=test jest",
     "prepare": "npm run build"
   },

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -4,7 +4,7 @@ import * as webrtc from '@signalwire/webrtc'
 export const sum = (a: number, b: number) => {
   if ('development' === process.env.NODE_ENV) {
     logger.info('Core feature', uuid())
-    logger.info('WebRTC feature', webrtc.sum(a, b))
+    logger.info('WebRTC feature', webrtc)
   }
 
   return a + b

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -6,7 +6,6 @@
   "exports": "./dist/index.modern.js",
   "module": "dist/index.esm.js",
   "unpkg": "dist/index.umd.js",
-  "types": "dist/web/src/index.d.ts",
   "files": [
     "dist",
     "src"
@@ -16,7 +15,7 @@
   },
   "scripts": {
     "start": "microbundle watch --external none -f es --tsconfig tsconfig.build.json",
-    "build": "microbundle --external none --define process.env.NODE_ENV=production --name VideoSDK --tsconfig ./tsconfig.build.json",
+    "build": "pkg-typings --pre-run && microbundle --external none --define process.env.NODE_ENV=production --name VideoSDK --tsconfig ./tsconfig.build.json && pkg-typings --after-run",
     "test": "NODE_ENV=test jest",
     "prepare": "npm run build",
     "example": "(cd examples && npm run dev)"
@@ -25,5 +24,6 @@
     "@signalwire/core": "0.0.0",
     "@signalwire/webrtc": "0.0.0",
     "regenerator-runtime": "^0.13.7"
-  }
+  },
+  "types": "dist/web/src/index.d.ts"
 }

--- a/packages/webrtc/package.json
+++ b/packages/webrtc/package.json
@@ -5,7 +5,6 @@
   "main": "dist/index.js",
   "exports": "./dist/index.modern.js",
   "module": "dist/index.esm.js",
-  "types": "dist/webrtc/src/index.d.ts",
   "files": [
     "dist",
     "src"
@@ -15,11 +14,12 @@
   },
   "scripts": {
     "start": "microbundle watch -f modern --tsconfig tsconfig.build.json",
-    "build": "microbundle --external none -f modern,es,cjs --define process.env.NODE_ENV=production --tsconfig ./tsconfig.build.json --target node",
+    "build": "pkg-typings --pre-run && microbundle --external none -f modern,es,cjs --define process.env.NODE_ENV=production --tsconfig ./tsconfig.build.json --target node && pkg-typings --after-run",
     "test": "NODE_ENV=test jest",
     "prepare": "npm run build build"
   },
   "dependencies": {
     "@signalwire/core": "0.0.0"
-  }
+  },
+  "types": "dist/webrtc/src/index.d.ts"
 }

--- a/scripts/pkg-typings/bin/cli.js
+++ b/scripts/pkg-typings/bin/cli.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import { cli } from '../index.js'
+
+cli(process.argv)

--- a/scripts/pkg-typings/index.js
+++ b/scripts/pkg-typings/index.js
@@ -1,0 +1,27 @@
+import fs from 'fs'
+import path from 'path'
+
+export function cli(args) {
+  const flags = args[2]
+  const filePath = path.resolve(process.cwd(), 'package.json')
+  const pkgJson = JSON.parse(fs.readFileSync(filePath, 'utf-8'))
+
+  switch (flags) {
+    case '--pre-run': {
+      pkgJson.types = ''
+
+      fs.writeFileSync(filePath, JSON.stringify(pkgJson, null, 2))
+
+      break
+    }
+    case '--after-run': {
+      const projectName = pkgJson.name.split('/')[1]
+
+      pkgJson.types = `dist/${projectName}/src/index.d.ts`
+
+      fs.writeFileSync(filePath, JSON.stringify(pkgJson, null, 2))
+
+      break
+    }
+  }
+}

--- a/scripts/pkg-typings/package.json
+++ b/scripts/pkg-typings/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@sw-internal/pkg-typings",
+  "version": "0.0.0",
+  "description": "A CLI for making sure each package points to the right typings",
+  "main": "index.js",
+  "type": "module",
+  "bin": {
+    "pkg-typings": "bin/cli.js"
+  }
+}

--- a/scripts/pkg-typings/package.json
+++ b/scripts/pkg-typings/package.json
@@ -4,6 +4,7 @@
   "description": "A CLI for making sure each package points to the right typings",
   "main": "index.js",
   "type": "module",
+  "private": true,
   "bin": {
     "pkg-typings": "bin/cli.js"
   }


### PR DESCRIPTION
The code in this changeset aims to fix #58 by providing a small CLI for handling the proper linking of each package to its own type definitions. 

The main problem was that `microbundle` wasn't able to generate the type definitions in the way we need it. When we manually defined `"types": "<path>"`,  `microbundle` uses it to generate the types but it does it in the wrong path (which makes the package not able to locate them). The other problem is that `"types"` is also the standard to define where the type definitions of your package are, which led us to the following problems:
1. If we manually define it (`"types"`), `microbundle` will generate the type definitions on a different path than the one we specified
2. If we don't manually specify it (literally removing it) the types gets generated in the proper location but we don't have a way to reference them since we don't have the `"types"` property defined.

To fix the above problems the new CLI tool will run before and after `microbundle` during our `build` process. 
1. During the first run it will take care of removing `"type"` from the corresponding `package.json` (for each package) so `microbundle` doesn't use it
2. After `microbundle` is done with the `build` process we run it again to update the `"type"` property and point it to the right location.