### PR TITLE
Add tests for "connect" and byId on ComponentState

### DIFF
--- a/packages/core/src/redux/connect.test.ts
+++ b/packages/core/src/redux/connect.test.ts
@@ -1,0 +1,75 @@
+import { Store } from 'redux'
+import { configureJestStore } from '../testUtils'
+import { BaseComponent } from '../BaseComponent'
+import { connect } from './connect'
+import { componentActions } from './features'
+import { EventEmitter } from '../utils/EventEmitter'
+
+describe('Connect', () => {
+  let store: Store
+  let instance: any
+  const mockOnRemoteSDP = jest.fn()
+
+  const updateStateAction = componentActions.update({
+    id: instance.id,
+    state: 'active',
+  })
+
+  const updateRemoteSDPAction = componentActions.update({
+    id: instance.id,
+    remoteSDP: '<SDP>',
+  })
+
+  beforeEach(() => {
+    store = configureJestStore()
+    instance = connect({
+      store,
+      onStateChangeListeners: {
+        state: 'emit',
+        remoteSDP: mockOnRemoteSDP,
+      },
+      Component: BaseComponent,
+    })({
+      emitter: EventEmitter(),
+    })
+    instance.emit = jest.fn()
+
+    mockOnRemoteSDP.mockClear()
+  })
+
+  it('should invoke the instance method if onStateChangeListeners provided a string name', () => {
+    store.dispatch(updateStateAction)
+
+    expect(instance.emit).toHaveBeenCalledTimes(1)
+    expect(instance.emit).toHaveBeenCalledWith({
+      id: instance.id,
+      state: 'active',
+    })
+  })
+
+  it('should unsubscribe after destroy', () => {
+    store.dispatch(updateStateAction)
+    expect(instance.emit).toHaveBeenCalledTimes(1)
+
+    instance.destroy()
+    instance.emit.mockClear()
+
+    store.dispatch(updateStateAction)
+    expect(instance.emit).not.toHaveBeenCalled()
+  })
+
+  it('should not invoke the instance method if something else in redux changed', () => {
+    store.dispatch(updateRemoteSDPAction)
+    expect(instance.emit).not.toHaveBeenCalled()
+  })
+
+  it('should invoke the function within onStateChangeListeners', () => {
+    store.dispatch(updateRemoteSDPAction)
+
+    expect(mockOnRemoteSDP).toHaveBeenCalledTimes(1)
+    expect(mockOnRemoteSDP).toHaveBeenCalledWith({
+      id: instance.id,
+      remoteSDP: '<SDP>',
+    })
+  })
+})

--- a/packages/core/src/redux/connect.test.ts
+++ b/packages/core/src/redux/connect.test.ts
@@ -8,17 +8,9 @@ import { EventEmitter } from '../utils/EventEmitter'
 describe('Connect', () => {
   let store: Store
   let instance: any
+  let updateStateAction: any
+  let updateRemoteSDPAction: any
   const mockOnRemoteSDP = jest.fn()
-
-  const updateStateAction = componentActions.update({
-    id: instance.id,
-    state: 'active',
-  })
-
-  const updateRemoteSDPAction = componentActions.update({
-    id: instance.id,
-    remoteSDP: '<SDP>',
-  })
 
   beforeEach(() => {
     store = configureJestStore()
@@ -35,6 +27,16 @@ describe('Connect', () => {
     instance.emit = jest.fn()
 
     mockOnRemoteSDP.mockClear()
+
+    updateStateAction = componentActions.update({
+      id: instance.id,
+      state: 'active',
+    })
+
+    updateRemoteSDPAction = componentActions.update({
+      id: instance.id,
+      remoteSDP: '<SDP>',
+    })
   })
 
   it('should invoke the instance method if onStateChangeListeners provided a string name', () => {

--- a/packages/core/src/redux/connect.ts
+++ b/packages/core/src/redux/connect.ts
@@ -17,7 +17,6 @@ export const connect = <T extends typeof BaseComponent>(
   const componentKeys = Object.keys(onStateChangeListeners)
 
   return (userOptions: any) => {
-    console.log('userOptions ?', { ...userOptions, store })
     const instance = new Component({ ...userOptions, store })
     const cacheMap = new Map<string, any>()
 

--- a/packages/core/src/redux/connect.ts
+++ b/packages/core/src/redux/connect.ts
@@ -17,6 +17,7 @@ export const connect = <T extends typeof BaseComponent>(
   const componentKeys = Object.keys(onStateChangeListeners)
 
   return (userOptions: any) => {
+    console.log('userOptions ?', { ...userOptions, store })
     const instance = new Component({ ...userOptions, store })
     const cacheMap = new Map<string, any>()
 

--- a/packages/core/src/redux/connect.ts
+++ b/packages/core/src/redux/connect.ts
@@ -1,40 +1,47 @@
 import { Store } from 'redux'
-import { ComponentState } from './interfaces'
+import { ReduxComponent } from './interfaces'
 import { BaseComponent } from '../BaseComponent'
 import { componentActions } from './features'
+import { getComponent } from './features/component/componentSelectors'
 
-type ConnectEventHandler = (state: ComponentState) => any
+type ConnectEventHandler = (component: ReduxComponent) => any
 interface Connect<T extends typeof BaseComponent> {
   onStateChangeListeners: Record<string, string | ConnectEventHandler>
   store: Store
   Component: T
 }
+type ReduxComponentKeys = keyof ReduxComponent
 
 export const connect = <T extends typeof BaseComponent>(
   options: Connect<T>
 ) => {
   const { onStateChangeListeners = {}, store, Component } = options
-  const componentKeys = Object.keys(onStateChangeListeners)
+  const componentKeys = Object.keys(
+    onStateChangeListeners
+  ) as ReduxComponentKeys[]
 
   return (userOptions: any) => {
     const instance = new Component({ ...userOptions, store })
     const cacheMap = new Map<string, any>()
 
     const storeUnsubscribe = store.subscribe(() => {
-      const { components = {} } = store.getState()
+      const component = getComponent(store.getState(), instance.id)
+      if (!component) {
+        return
+      }
       componentKeys.forEach((key) => {
         const current = cacheMap.get(key)
-        const updatedValue = components?.[instance.id]?.[key]
+        const updatedValue = component?.[key]
         if (updatedValue !== undefined && current !== updatedValue) {
           cacheMap.set(key, updatedValue)
           const fnName = onStateChangeListeners[key]
 
           if (typeof fnName === 'string') {
-            // FIXME: fixing TS error typing fnName properly
+            // FIXME: proper types for fnName
             // @ts-ignore
-            instance[fnName](components[instance.id])
+            instance[fnName](component)
           } else {
-            fnName(components[instance.id])
+            fnName(component)
           }
         }
       })

--- a/packages/core/src/redux/features/component/componentSelectors.ts
+++ b/packages/core/src/redux/features/component/componentSelectors.ts
@@ -1,5 +1,5 @@
 import { SDKState } from '../../interfaces'
 
 export const getComponent = ({ components }: SDKState, id: string) => {
-  return components?.[id]
+  return components.byId?.[id]
 }

--- a/packages/core/src/redux/features/component/componentSlice.test.ts
+++ b/packages/core/src/redux/features/component/componentSlice.test.ts
@@ -6,7 +6,7 @@ import { destroyAction, executeAction } from '../../actions'
 import { ReduxComponent } from '../../interfaces'
 import { JSONRPCResponse } from '../../../utils/interfaces'
 
-describe('SessionState Tests', () => {
+describe('ComponentState Tests', () => {
   let store: Store
   const requestId = 'faa63915-3a64-4c39-acbb-06dac0758f8a'
   const componentId = '268b4cf8-a3c5-4003-8666-3b7a4f0a5af9'
@@ -64,7 +64,7 @@ describe('SessionState Tests', () => {
 
     it('should not change the state if the componentId does not exist', () => {
       store.dispatch(executeSuccessAction)
-      expect(store.getState().components).toStrictEqual({})
+      expect(store.getState().components).toStrictEqual(initialComponentState)
     })
 
     it('should update the state properly including the response', () => {
@@ -105,7 +105,7 @@ describe('SessionState Tests', () => {
 
     it('should not change the state if the componentId does not exist', () => {
       store.dispatch(executeFailureAction)
-      expect(store.getState().components).toStrictEqual({})
+      expect(store.getState().components).toStrictEqual(initialComponentState)
     })
 
     it('should update the state properly including both the action request and the error response', () => {

--- a/packages/core/src/redux/features/component/componentSlice.ts
+++ b/packages/core/src/redux/features/component/componentSlice.ts
@@ -3,7 +3,9 @@ import { JSONRPCResponse } from '../../../utils/interfaces'
 import { ComponentState, ReduxComponent } from '../../interfaces'
 import { destroyAction } from '../../actions'
 
-export const initialComponentState: Readonly<ComponentState> = {}
+export const initialComponentState: Readonly<ComponentState> = {
+  byId: {},
+}
 
 type UpdateComponent = Partial<ReduxComponent> & Pick<ReduxComponent, 'id'>
 
@@ -24,29 +26,30 @@ const componentSlice = createSlice({
   initialState: initialComponentState,
   reducers: {
     update: (state, { payload }: PayloadAction<UpdateComponent>) => {
-      if (payload.id in state) {
+      if (payload.id in state.byId) {
         // To avoid spread operator, update only the keys passed in.
         Object.keys(payload).forEach((key) => {
           // @ts-ignore
-          state[payload.id][key] = payload[key]
+          state.byId[payload.id][key] = payload[key]
         })
       } else {
         // If not in state already, set directly using the id.
-        state[payload.id] = payload
+        state.byId[payload.id] = payload
       }
     },
     executeSuccess: (state, { payload }: PayloadAction<SuccessParams>) => {
       const { componentId, requestId, response } = payload
-      if (state[componentId]) {
-        state[componentId].responses = state[componentId].responses || {}
-        state[componentId].responses![requestId] = response
+      if (state.byId[componentId]) {
+        state.byId[componentId].responses =
+          state.byId[componentId].responses || {}
+        state.byId[componentId].responses![requestId] = response
       }
     },
     executeFailure: (state, { payload }: PayloadAction<FailureParams>) => {
       const { componentId, requestId, error, action } = payload
-      if (state[componentId]) {
-        state[componentId].errors = state[componentId].errors || {}
-        state[componentId].errors![requestId] = {
+      if (state.byId[componentId]) {
+        state.byId[componentId].errors = state.byId[componentId].errors || {}
+        state.byId[componentId].errors![requestId] = {
           action,
           jsonrpc: error,
         }

--- a/packages/core/src/redux/index.ts
+++ b/packages/core/src/redux/index.ts
@@ -3,7 +3,7 @@ import createSagaMiddleware, { Saga } from 'redux-saga'
 import { rootReducer } from './rootReducer'
 import rootSaga from './rootSaga'
 import { GetDefaultSagas, SDKState } from './interfaces'
-import { connect } from './utils'
+import { connect } from './connect'
 import { UserOptions, SessionConstructor } from '../utils/interfaces'
 
 interface ConfigureStoreOptions {

--- a/packages/core/src/redux/interfaces.ts
+++ b/packages/core/src/redux/interfaces.ts
@@ -27,7 +27,9 @@ export interface Message extends SWComponent {
 export type ReduxComponent = WebRTCCall | Message
 
 export interface ComponentState {
-  [key: string]: ReduxComponent
+  byId: {
+    [key: string]: ReduxComponent
+  }
 }
 
 export interface SessionState {


### PR DESCRIPTION
This PR includes initial tests for the `connect()` function and also the `byId` key within ComponentState that would be helpful in the future. 