### PR TITLE
Add error handling for the initial Authentication process

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,7 @@
     "node": ">=10"
   },
   "scripts": {
-    "start": "microbundle watch -f modern --tsconfig tsconfig.build.json",
+    "start": "microbundle watch -f modern,es --tsconfig tsconfig.build.json",
     "build": "pkg-typings --pre-run && microbundle --external none -f modern,es,cjs --define process.env.NODE_ENV=production --tsconfig ./tsconfig.build.json --target node && pkg-typings --after-run",
     "test": "NODE_ENV=test jest",
     "prepare": "npm run build"

--- a/packages/core/src/CustomErrors.ts
+++ b/packages/core/src/CustomErrors.ts
@@ -1,0 +1,8 @@
+export class AuthError extends Error {
+  name = 'AuthError'
+
+  constructor(public code: number, public message: string) {
+    super(message)
+    Object.setPrototypeOf(this, AuthError.prototype)
+  }
+}

--- a/packages/core/src/JWTSession.ts
+++ b/packages/core/src/JWTSession.ts
@@ -85,8 +85,9 @@ export class JWTSession extends Session {
       this._bladeConnectResult = await this.execute(BladeConnect(params))
       this._checkTokenExpiration()
     } catch (error) {
-      // FIXME: Handle Auth Error
-      console.error('Auth Error', error)
+      // TODO: Do we want to log this?
+      // console.error('Auth Error', error)
+      this._authError = error
     }
   }
 

--- a/packages/core/src/Session.ts
+++ b/packages/core/src/Session.ts
@@ -7,6 +7,7 @@ import {
   BladePingResponse,
 } from './RPCMessages'
 import {
+  SessionAuthStatus,
   SessionOptions,
   SessionRequestObject,
   SessionRequestQueued,
@@ -21,12 +22,6 @@ import {
   parseRPCResponse,
   safeParseJson,
 } from './utils'
-
-type SessionAuthStatus =
-  | 'unknown'
-  | 'authorizing'
-  | 'authorized'
-  | 'unauthorized'
 export class Session {
   public uuid = uuid()
   public sessionid = ''

--- a/packages/core/src/Session.ts
+++ b/packages/core/src/Session.ts
@@ -14,6 +14,7 @@ import {
   IBladeConnectResult,
   JSONRPCRequest,
   JSONRPCResponse,
+  SessionAuthError,
 } from './utils/interfaces'
 
 import {
@@ -29,6 +30,7 @@ export class Session {
 
   protected _bladeConnectResult: IBladeConnectResult
   protected _authStatus: SessionAuthStatus = 'unknown'
+  protected _authError?: SessionAuthError
 
   private _requests = new Map<string, SessionRequestObject>()
   private _requestQueue: SessionRequestQueued[] = []
@@ -69,6 +71,10 @@ export class Session {
     }
 
     return this._authStatus
+  }
+
+  get authError() {
+    return this._authError
   }
 
   get bladeConnectResult() {
@@ -232,6 +238,7 @@ export class Session {
   protected async _onSocketOpen(event: Event) {
     logger.debug('_onSocketOpen', event)
     this._idle = false
+    this._authError = undefined
     this._authStatus = 'authorizing'
     await this.authenticate()
     this._emptyRequestQueue()

--- a/packages/core/src/Session.ts
+++ b/packages/core/src/Session.ts
@@ -7,6 +7,7 @@ import {
   BladePingResponse,
 } from './RPCMessages'
 import {
+  SessionAuthError,
   SessionAuthStatus,
   SessionOptions,
   SessionRequestObject,
@@ -14,7 +15,6 @@ import {
   IBladeConnectResult,
   JSONRPCRequest,
   JSONRPCResponse,
-  SessionAuthError,
 } from './utils/interfaces'
 
 import {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,6 +29,7 @@ export {
   VertoMethod,
   ConferenceMethod,
 } from './utils/constants'
+export * as CustomErrors from './CustomErrors'
 
 export const selectors = {
   ...sessionSelectors,

--- a/packages/core/src/redux/features/session/sessionSlice.ts
+++ b/packages/core/src/redux/features/session/sessionSlice.ts
@@ -2,6 +2,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { SessionState } from '../../interfaces'
 import {
   IBladeConnectResult,
+  SessionAuthError,
   SessionAuthStatus,
 } from '../../../utils/interfaces'
 import { destroyAction } from '../../actions'
@@ -20,8 +21,14 @@ const sessionSlice = createSlice({
       state.protocol = payload?.result?.protocol ?? ''
       state.iceServers = payload?.result?.iceServers ?? []
     },
-    validated: (state, { payload }: PayloadAction<SessionAuthStatus>) => {
-      state.authStatus = payload
+    validated: (
+      state,
+      {
+        payload,
+      }: PayloadAction<{ status: SessionAuthStatus; error?: SessionAuthError }>
+    ) => {
+      state.authStatus = payload.status
+      state.authError = payload.error
     },
   },
   extraReducers: (builder) => {

--- a/packages/core/src/redux/features/session/sessionSlice.ts
+++ b/packages/core/src/redux/features/session/sessionSlice.ts
@@ -1,11 +1,15 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { SessionState } from '../../interfaces'
-import { IBladeConnectResult } from '../../../utils/interfaces'
+import {
+  IBladeConnectResult,
+  SessionAuthStatus,
+} from '../../../utils/interfaces'
 import { destroyAction } from '../../actions'
 
 export const initialSessionState: Readonly<SessionState> = {
   protocol: '',
   iceServers: [],
+  authStatus: 'unknown',
 }
 
 const sessionSlice = createSlice({
@@ -15,6 +19,9 @@ const sessionSlice = createSlice({
     connected: (state, { payload }: PayloadAction<IBladeConnectResult>) => {
       state.protocol = payload?.result?.protocol ?? ''
       state.iceServers = payload?.result?.iceServers ?? []
+    },
+    validated: (state, { payload }: PayloadAction<SessionAuthStatus>) => {
+      state.authStatus = payload
     },
   },
   extraReducers: (builder) => {

--- a/packages/core/src/redux/interfaces.ts
+++ b/packages/core/src/redux/interfaces.ts
@@ -1,6 +1,10 @@
 import { Saga } from '@redux-saga/types'
 import { PayloadAction } from '@reduxjs/toolkit'
-import { JSONRPCResponse, SessionAuthStatus } from '../utils/interfaces'
+import {
+  JSONRPCResponse,
+  SessionAuthError,
+  SessionAuthStatus,
+} from '../utils/interfaces'
 
 interface SWComponent {
   id: string
@@ -36,6 +40,7 @@ export interface SessionState {
   protocol: string
   iceServers?: RTCIceServer[]
   authStatus: SessionAuthStatus
+  authError?: SessionAuthError
 }
 
 export interface SDKState {

--- a/packages/core/src/redux/interfaces.ts
+++ b/packages/core/src/redux/interfaces.ts
@@ -1,6 +1,6 @@
 import { Saga } from '@redux-saga/types'
 import { PayloadAction } from '@reduxjs/toolkit'
-import { JSONRPCResponse } from '../utils/interfaces'
+import { JSONRPCResponse, SessionAuthStatus } from '../utils/interfaces'
 
 interface SWComponent {
   id: string
@@ -35,6 +35,7 @@ export interface ComponentState {
 export interface SessionState {
   protocol: string
   iceServers?: RTCIceServer[]
+  authStatus: SessionAuthStatus
 }
 
 export interface SDKState {

--- a/packages/core/src/redux/rootSaga.ts
+++ b/packages/core/src/redux/rootSaga.ts
@@ -70,6 +70,7 @@ export default (options: RootSagaOptions) => {
       session
     )
     yield put(sessionActions.connected(session.bladeConnectResult))
+    yield put(sessionActions.validated(session.authStatus))
 
     /**
      * Create a channel to communicate between sagas

--- a/packages/core/src/redux/rootSaga.ts
+++ b/packages/core/src/redux/rootSaga.ts
@@ -70,7 +70,12 @@ export default (options: RootSagaOptions) => {
       session
     )
     yield put(sessionActions.connected(session.bladeConnectResult))
-    yield put(sessionActions.validated(session.authStatus))
+    yield put(
+      sessionActions.validated({
+        status: session.authStatus,
+        error: session.authError,
+      })
+    )
 
     /**
      * Create a channel to communicate between sagas

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -43,6 +43,12 @@ export interface SessionOptions {
   autoConnect?: boolean
 }
 
+export type SessionAuthStatus =
+  | 'unknown'
+  | 'authorizing'
+  | 'authorized'
+  | 'unauthorized'
+
 export interface UserOptions<T = {}> extends SessionOptions {
   devTools?: boolean
   emitter?: Emitter<T>

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -49,6 +49,9 @@ export type SessionAuthStatus =
   | 'authorized'
   | 'unauthorized'
 
+// FIXME: add proper type
+export type SessionAuthError = any
+
 export interface UserOptions<T = {}> extends SessionOptions {
   devTools?: boolean
   emitter?: Emitter<T>

--- a/packages/web/examples/ts-vanilla/index.ts
+++ b/packages/web/examples/ts-vanilla/index.ts
@@ -6,18 +6,22 @@ import { createSession } from '../../src'
 
 // @ts-ignore
 window._makeClient = async ({ project, token, emitter }) => {
-  const client = await createSession({
-    host: 'relay.swire.io',
-    project,
-    token,
-    autoConnect: true,
-    onReady: async () => {
-      console.debug('Session Ready')
-    },
-    emitter,
-  })
+  try {
+    const client = await createSession({
+      host: 'relay.swire.io',
+      project,
+      token,
+      autoConnect: true,
+      onReady: async () => {
+        console.debug('Session Ready')
+      },
+      emitter,
+    })
 
-  // @ts-ignore
-  window.__client = client
-  return client
+    // @ts-ignore
+    window.__client = client
+    return client
+  } catch (e) {
+    console.log('Error', e)
+  }
 }

--- a/packages/web/examples/ts-vanilla/index.ts
+++ b/packages/web/examples/ts-vanilla/index.ts
@@ -22,6 +22,7 @@ window._makeClient = async ({ project, token, emitter }) => {
     window.__client = client
     return client
   } catch (e) {
-    console.log('Error', e)
+    console.error('Error Code', e.code)
+    console.error('Error Message', e.message)
   }
 }

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -51,13 +51,18 @@ export const createSession = (userOptions: UserOptions): Promise<Client> => {
     if (baseUserOptions.autoConnect) {
       const unsubscribe = store.subscribe(() => {
         const state = store.getState()
+        const session = state.session
 
-        if (state.session.authStatus === 'authorized') {
+        if (session.authStatus === 'authorized') {
           resolve(client)
           unsubscribe()
-        } else if (state.session.authStatus === 'unauthorized') {
-          // TODO: replace with proper error obj
-          reject(new CustomErrors.AuthError(200, 'some-error'))
+        } else if (session.authStatus === 'unauthorized') {
+          const authError = session.authError
+          const error = authError
+            ? new CustomErrors.AuthError(authError.code, authError.message)
+            : new Error('Unauthorized')
+
+          reject(error)
           unsubscribe()
         }
       })

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -7,6 +7,7 @@ import {
   UserOptions,
   getEventEmitter,
   BaseComponent,
+  CustomErrors,
 } from '@signalwire/core'
 import { Call } from '@signalwire/webrtc'
 
@@ -37,7 +38,7 @@ export class Client extends SignalWire {
 }
 
 export const createSession = (userOptions: UserOptions): Promise<Client> => {
-  return new Promise((resolve, _reject) => {
+  return new Promise((resolve, reject) => {
     const baseUserOptions: UserOptions = {
       ...userOptions,
       emitter: getEventEmitter(userOptions),
@@ -51,8 +52,12 @@ export const createSession = (userOptions: UserOptions): Promise<Client> => {
       const unsubscribe = store.subscribe(() => {
         const state = store.getState()
 
-        if (state.session.protocol) {
+        if (state.session.authStatus === 'authorized') {
           resolve(client)
+          unsubscribe()
+        } else if (state.session.authStatus === 'unauthorized') {
+          // TODO: replace with proper error obj
+          reject(new CustomErrors.AuthError(200, 'some-error'))
           unsubscribe()
         }
       })


### PR DESCRIPTION
The code in this changeset includes error handling for the initial `authentication` process when creating the base `Session` object along with an updated example of how to consume it from `web`. 