### PR TITLE
Update ExecuteActionParams to re-use the saga watcher

### DIFF
--- a/packages/core/src/redux/features/session/sessionSaga.ts
+++ b/packages/core/src/redux/features/session/sessionSaga.ts
@@ -150,26 +150,6 @@ export function* sessionChannelWatcher({
       //   const call = _buildCall(session, params, attach, nodeId)
       //   return trigger(call.id, params, method)
       // }
-      // case VertoMethod.Event:
-      // case 'webrtc.event': {
-      //   const { subscribedChannel } = params
-      //   if (
-      //     subscribedChannel &&
-      //     trigger(session.relayProtocol, params, subscribedChannel)
-      //   ) {
-      //     return
-      //   }
-      //   if (eventChannel) {
-      //     const channelType = eventChannel.split('.')[0]
-      //     const global = trigger(session.relayProtocol, params, channelType)
-      //     const specific = trigger(session.relayProtocol, params, eventChannel)
-      //     if (global || specific) {
-      //       return
-      //     }
-      //   }
-      //   params.type = Notification.Generic
-      //   return trigger(SwEvent.Notification, params, session.uuid)
-      // }
       case VertoMethod.Info:
         return logger.debug('Verto Info', params)
       case VertoMethod.ClientReady:

--- a/packages/core/src/redux/features/session/sessionSaga.ts
+++ b/packages/core/src/redux/features/session/sessionSaga.ts
@@ -237,7 +237,6 @@ export function* sessionChannelWatcher({
         yield fork(bladeBroadcastWorker, params)
         break
       default:
-        // yield put(action)
         return logger.debug(`Unknown message: ${method}`, payload)
     }
   }
@@ -261,7 +260,6 @@ export function* sessionChannelWatcher({
 
 export function createSessionChannel(session: Session) {
   return eventChannel((emit) => {
-    // TODO: Replace eventHandler with .on() notation ?
     session.eventHandler = (payload: any) => {
       emit(payload)
     }

--- a/packages/core/src/redux/interfaces.ts
+++ b/packages/core/src/redux/interfaces.ts
@@ -48,8 +48,8 @@ export interface SDKState {
 export type GetDefaultSagas = () => Saga[]
 
 export interface ExecuteActionParams {
-  requestId: string
-  componentId: string
+  requestId?: string
+  componentId?: string
   method: string
   params: Record<string, any>
 }


### PR DESCRIPTION
This PR makes the `executeAction` watcher within sessionSaga reusable to just execute API like fire-and-forget (instead of waiting for the response and update the State.