### PR TITLE
update package lock with npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,12 +56,13 @@
       "license": "MIT"
     },
     "examples/with-next.js/node_modules/postcss": {
-      "version": "8.2.12",
+      "version": "8.2.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.15.tgz",
+      "integrity": "sha512-2zO3b26eJD/8rb106Qu2o7Qgg52ND5HPjcyQiK2B98O388h43A448LCslC0dI2P97wCAQRJsFvwTRcXxTKds+Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "colorette": "^1.2.2",
-        "nanoid": "^3.1.22",
+        "nanoid": "^3.1.23",
         "source-map": "^0.6.1"
       },
       "engines": {
@@ -3067,16 +3068,19 @@
       "dev": true
     },
     "node_modules/@next/env": {
-      "version": "10.1.3",
-      "license": "MIT"
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-10.2.0.tgz",
+      "integrity": "sha512-tsWBsn1Rb6hXRaHc/pWMCpZ4Ipkf3OCbZ54ef5ukgIyEvzzGdGFXQshPP2AF7yb+8yMpunWs7vOMZW3e8oPF6A=="
     },
     "node_modules/@next/polyfill-module": {
-      "version": "10.1.3",
-      "license": "MIT"
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-10.2.0.tgz",
+      "integrity": "sha512-Nl3GexIUXsmuggkUqrRFyE/2k7UI44JaVzSywtXEyHzxpZm2a5bdMaWuC89pgLiFDDOqmbqyLAbtwm5lNxa7Eg=="
     },
     "node_modules/@next/react-dev-overlay": {
-      "version": "10.1.3",
-      "license": "MIT",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-10.2.0.tgz",
+      "integrity": "sha512-PRIAoWog41hLN4iJ8dChKp4ysOX0Q8yiNQ/cwzyqEd3EjugkDV5OiKl3mumGKaApJaIra1MX6j1wgQRuLhuWMA==",
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "anser": "1.4.9",
@@ -3097,21 +3101,24 @@
     },
     "node_modules/@next/react-dev-overlay/node_modules/@babel/code-frame": {
       "version": "7.12.11",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
       "dependencies": {
         "@babel/highlight": "^7.10.4"
       }
     },
     "node_modules/@next/react-dev-overlay/node_modules/ansi-regex": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@next/react-dev-overlay/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -3124,7 +3131,8 @@
     },
     "node_modules/@next/react-dev-overlay/node_modules/chalk": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
+      "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -3138,7 +3146,8 @@
     },
     "node_modules/@next/react-dev-overlay/node_modules/color-convert": {
       "version": "2.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -3148,18 +3157,21 @@
     },
     "node_modules/@next/react-dev-overlay/node_modules/color-name": {
       "version": "1.1.4",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/@next/react-dev-overlay/node_modules/has-flag": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@next/react-dev-overlay/node_modules/source-map": {
       "version": "0.8.0-beta.0",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+      "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
       "dependencies": {
         "whatwg-url": "^7.0.0"
       },
@@ -3169,7 +3181,8 @@
     },
     "node_modules/@next/react-dev-overlay/node_modules/strip-ansi": {
       "version": "6.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
       "dependencies": {
         "ansi-regex": "^5.0.0"
       },
@@ -3179,7 +3192,8 @@
     },
     "node_modules/@next/react-dev-overlay/node_modules/supports-color": {
       "version": "7.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -3188,8 +3202,9 @@
       }
     },
     "node_modules/@next/react-refresh-utils": {
-      "version": "10.1.3",
-      "license": "MIT",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-10.2.0.tgz",
+      "integrity": "sha512-3I31K9B4hEQRl7yQ44Umyz+szHtuMJrNdwsgJGhoEnUCXSBRHp5wv5Zv8eDa2NewSbe53b2C0oOpivrzmdBakw==",
       "peerDependencies": {
         "react-refresh": "0.8.3",
         "webpack": "^4 || ^5"
@@ -3717,7 +3732,8 @@
     },
     "node_modules/anser": {
       "version": "1.4.9",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/anser/-/anser-1.4.9.tgz",
+      "integrity": "sha512-AI+BjTeGt2+WFk4eWcqbQ7snZpDBt8SaLlj0RT2h5xfdWaiy51OjYvqwMrNzJLGy8iOAL6nKDITWO+rd4MkYEA=="
     },
     "node_modules/ansi-align": {
       "version": "2.0.0",
@@ -4760,7 +4776,8 @@
     },
     "node_modules/classnames": {
       "version": "2.2.6",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
     },
     "node_modules/cli-boxes": {
       "version": "1.0.0",
@@ -5362,7 +5379,8 @@
     },
     "node_modules/css.escape": {
       "version": "1.5.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s="
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -5460,85 +5478,25 @@
       }
     },
     "node_modules/cssnano-preset-simple": {
-      "version": "1.2.2",
-      "license": "MIT",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-simple/-/cssnano-preset-simple-2.0.0.tgz",
+      "integrity": "sha512-HkufSLkaBJbKBFx/7aj5HmCK9Ni/JedRQm0mT2qBzMG/dEuJOLnMt2lK6K1rwOOyV4j9aSY+knbW9WoS7BYpzg==",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001179",
-        "postcss": "^7.0.32"
-      }
-    },
-    "node_modules/cssnano-preset-simple/node_modules/postcss": {
-      "version": "7.0.35",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^2.4.2",
-        "source-map": "^0.6.1",
-        "supports-color": "^6.1.0"
+        "caniuse-lite": "^1.0.30001202"
       },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      }
-    },
-    "node_modules/cssnano-preset-simple/node_modules/source-map": {
-      "version": "0.6.1",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/cssnano-preset-simple/node_modules/supports-color": {
-      "version": "6.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/cssnano-simple": {
-      "version": "1.2.2",
-      "license": "MIT",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cssnano-simple/-/cssnano-simple-2.0.0.tgz",
+      "integrity": "sha512-0G3TXaFxlh/szPEG/o3VcmCwl0N3E60XNb9YZZijew5eIs6fLjJuOPxQd9yEBaX2p/YfJtt49i4vYi38iH6/6w==",
       "dependencies": {
-        "cssnano-preset-simple": "1.2.2",
-        "postcss": "^7.0.32"
-      }
-    },
-    "node_modules/cssnano-simple/node_modules/postcss": {
-      "version": "7.0.35",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^2.4.2",
-        "source-map": "^0.6.1",
-        "supports-color": "^6.1.0"
+        "cssnano-preset-simple": "^2.0.0"
       },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      }
-    },
-    "node_modules/cssnano-simple/node_modules/source-map": {
-      "version": "0.6.1",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/cssnano-simple/node_modules/supports-color": {
-      "version": "6.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
+      "peerDependencies": {
+        "postcss": "^8.2.2"
       }
     },
     "node_modules/cssnano-util-get-arguments": {
@@ -5772,7 +5730,8 @@
     },
     "node_modules/data-uri-to-buffer": {
       "version": "3.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
       "engines": {
         "node": ">= 6"
       }
@@ -7510,8 +7469,9 @@
       }
     },
     "node_modules/hosted-git-info": {
-      "version": "2.8.8",
-      "license": "ISC"
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
     },
     "node_modules/hsl-regex": {
       "version": "1.0.0",
@@ -11263,24 +11223,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/line-column": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "isarray": "^1.0.0",
-        "isobject": "^2.0.0"
-      }
-    },
-    "node_modules/line-column/node_modules/isobject": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "isarray": "1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/lines-and-columns": {
       "version": "1.1.6",
       "license": "MIT"
@@ -11364,7 +11306,8 @@
     },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
     },
     "node_modules/lodash.startcase": {
       "version": "4.4.0",
@@ -12014,8 +11957,9 @@
       }
     },
     "node_modules/mixme": {
-      "version": "0.4.0",
-      "license": "MIT",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mixme/-/mixme-0.5.1.tgz",
+      "integrity": "sha512-NaeZIckeBFT7i0XBEpGyFcAE0/bLcQ9MHErTpnU3bLWVE5WZbxG5Y3fDsMxYGifTo5khDA42OquXCC2ngKJB+g==",
       "engines": {
         "node": ">= 8.0.0"
       }
@@ -12287,8 +12231,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.1.22",
-      "license": "MIT",
+      "version": "3.1.23",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -12328,15 +12273,16 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "10.1.3",
-      "license": "MIT",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-10.2.0.tgz",
+      "integrity": "sha512-PKDKCSF7s82xudu3kQhOEaokxggpbLEWouEUtzP6OqV0YqKYHF+Ff+BFLycEem8ixtTM2M6ElN0VRJcskJfxPQ==",
       "dependencies": {
         "@babel/runtime": "7.12.5",
         "@hapi/accept": "5.0.1",
-        "@next/env": "10.1.3",
-        "@next/polyfill-module": "10.1.3",
-        "@next/react-dev-overlay": "10.1.3",
-        "@next/react-refresh-utils": "10.1.3",
+        "@next/env": "10.2.0",
+        "@next/polyfill-module": "10.2.0",
+        "@next/react-dev-overlay": "10.2.0",
+        "@next/react-refresh-utils": "10.2.0",
         "@opentelemetry/api": "0.14.0",
         "assert": "2.0.0",
         "ast-types": "0.13.2",
@@ -12348,7 +12294,7 @@
         "chokidar": "3.5.1",
         "constants-browserify": "1.0.0",
         "crypto-browserify": "3.12.0",
-        "cssnano-simple": "1.2.2",
+        "cssnano-simple": "2.0.0",
         "domain-browser": "4.19.0",
         "encoding": "0.1.13",
         "etag": "1.8.1",
@@ -12364,7 +12310,7 @@
         "p-limit": "3.1.0",
         "path-browserify": "1.0.1",
         "pnp-webpack-plugin": "1.6.4",
-        "postcss": "8.1.7",
+        "postcss": "8.2.13",
         "process": "0.11.10",
         "prop-types": "15.7.2",
         "querystring-es3": "0.2.1",
@@ -12465,30 +12411,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.1.7",
-      "license": "MIT",
-      "dependencies": {
-        "colorette": "^1.2.1",
-        "line-column": "^1.0.2",
-        "nanoid": "^3.1.16",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      }
-    },
-    "node_modules/next/node_modules/source-map": {
-      "version": "0.6.1",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/next/node_modules/supports-color": {
@@ -13305,7 +13227,8 @@
     },
     "node_modules/platform": {
       "version": "1.3.6",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
     },
     "node_modules/pnp-webpack-plugin": {
       "version": "1.6.4",
@@ -13325,8 +13248,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.2.12",
-      "license": "MIT",
+      "version": "8.2.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.13.tgz",
+      "integrity": "sha512-FCE5xLH+hjbzRdpbRb1IMCvPv9yZx2QnDarBEYSN0N0HYk+TcXsEhwdFcFb+SRWOKzKGErhIEbBK2ogyLdTtfQ==",
       "dependencies": {
         "colorette": "^1.2.2",
         "nanoid": "^3.1.22",
@@ -15274,7 +15198,8 @@
     },
     "node_modules/react-refresh": {
       "version": "0.8.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
+      "integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16291,7 +16216,8 @@
     },
     "node_modules/shell-quote": {
       "version": "1.7.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
+      "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg=="
     },
     "node_modules/shellwords": {
       "version": "0.1.1",
@@ -16598,7 +16524,8 @@
     },
     "node_modules/stacktrace-parser": {
       "version": "0.1.10",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.10.tgz",
+      "integrity": "sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==",
       "dependencies": {
         "type-fest": "^0.7.1"
       },
@@ -16608,7 +16535,8 @@
     },
     "node_modules/stacktrace-parser/node_modules/type-fest": {
       "version": "0.7.1",
-      "license": "(MIT OR CC0-1.0)",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
+      "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==",
       "engines": {
         "node": ">=8"
       }
@@ -16674,10 +16602,11 @@
       }
     },
     "node_modules/stream-transform": {
-      "version": "2.0.4",
-      "license": "MIT",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-2.1.0.tgz",
+      "integrity": "sha512-bwQO+75rzQbug7e5OOHnOR3FgbJ0fCjHmDIdynkwUaFzleBXugGmv2dx3sX3aIHUQRLjrcisRPgN9BWl63uGgw==",
       "dependencies": {
-        "mixme": "^0.4.0"
+        "mixme": "^0.5.0"
       }
     },
     "node_modules/strict-event-emitter": {
@@ -17341,7 +17270,8 @@
     },
     "node_modules/tr46": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -17915,7 +17845,8 @@
     },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",
-      "license": "BSD-2-Clause"
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
     },
     "node_modules/whatwg-encoding": {
       "version": "1.0.5",
@@ -17930,7 +17861,8 @@
     },
     "node_modules/whatwg-url": {
       "version": "7.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
       "dependencies": {
         "lodash.sortby": "^4.7.0",
         "tr46": "^1.0.1",
@@ -20401,13 +20333,19 @@
       }
     },
     "@next/env": {
-      "version": "10.1.3"
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-10.2.0.tgz",
+      "integrity": "sha512-tsWBsn1Rb6hXRaHc/pWMCpZ4Ipkf3OCbZ54ef5ukgIyEvzzGdGFXQshPP2AF7yb+8yMpunWs7vOMZW3e8oPF6A=="
     },
     "@next/polyfill-module": {
-      "version": "10.1.3"
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-10.2.0.tgz",
+      "integrity": "sha512-Nl3GexIUXsmuggkUqrRFyE/2k7UI44JaVzSywtXEyHzxpZm2a5bdMaWuC89pgLiFDDOqmbqyLAbtwm5lNxa7Eg=="
     },
     "@next/react-dev-overlay": {
-      "version": "10.1.3",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-10.2.0.tgz",
+      "integrity": "sha512-PRIAoWog41hLN4iJ8dChKp4ysOX0Q8yiNQ/cwzyqEd3EjugkDV5OiKl3mumGKaApJaIra1MX6j1wgQRuLhuWMA==",
       "requires": {
         "@babel/code-frame": "7.12.11",
         "anser": "1.4.9",
@@ -20424,21 +20362,29 @@
       "dependencies": {
         "@babel/code-frame": {
           "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+          "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
           "requires": {
             "@babel/highlight": "^7.10.4"
           }
         },
         "ansi-regex": {
-          "version": "5.0.0"
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
         },
         "ansi-styles": {
           "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "requires": {
             "color-convert": "^2.0.1"
           }
         },
         "chalk": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
+          "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -20446,30 +20392,42 @@
         },
         "color-convert": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "requires": {
             "color-name": "~1.1.4"
           }
         },
         "color-name": {
-          "version": "1.1.4"
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "has-flag": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "source-map": {
           "version": "0.8.0-beta.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+          "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
           "requires": {
             "whatwg-url": "^7.0.0"
           }
         },
         "strip-ansi": {
           "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "requires": {
             "ansi-regex": "^5.0.0"
           }
         },
         "supports-color": {
           "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -20477,7 +20435,9 @@
       }
     },
     "@next/react-refresh-utils": {
-      "version": "10.1.3",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-10.2.0.tgz",
+      "integrity": "sha512-3I31K9B4hEQRl7yQ44Umyz+szHtuMJrNdwsgJGhoEnUCXSBRHp5wv5Zv8eDa2NewSbe53b2C0oOpivrzmdBakw==",
       "requires": {}
     },
     "@nodelib/fs.scandir": {
@@ -20902,7 +20862,9 @@
       "version": "1.0.2"
     },
     "anser": {
-      "version": "1.4.9"
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/anser/-/anser-1.4.9.tgz",
+      "integrity": "sha512-AI+BjTeGt2+WFk4eWcqbQ7snZpDBt8SaLlj0RT2h5xfdWaiy51OjYvqwMrNzJLGy8iOAL6nKDITWO+rd4MkYEA=="
     },
     "ansi-align": {
       "version": "2.0.0",
@@ -21569,7 +21531,9 @@
       }
     },
     "classnames": {
-      "version": "2.2.6"
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
     },
     "cli-boxes": {
       "version": "1.0.0"
@@ -21973,7 +21937,9 @@
       "version": "3.4.2"
     },
     "css.escape": {
-      "version": "1.5.1"
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s="
     },
     "cssesc": {
       "version": "3.0.0"
@@ -22087,55 +22053,19 @@
       }
     },
     "cssnano-preset-simple": {
-      "version": "1.2.2",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-simple/-/cssnano-preset-simple-2.0.0.tgz",
+      "integrity": "sha512-HkufSLkaBJbKBFx/7aj5HmCK9Ni/JedRQm0mT2qBzMG/dEuJOLnMt2lK6K1rwOOyV4j9aSY+knbW9WoS7BYpzg==",
       "requires": {
-        "caniuse-lite": "^1.0.30001179",
-        "postcss": "^7.0.32"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "7.0.35",
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1"
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
+        "caniuse-lite": "^1.0.30001202"
       }
     },
     "cssnano-simple": {
-      "version": "1.2.2",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cssnano-simple/-/cssnano-simple-2.0.0.tgz",
+      "integrity": "sha512-0G3TXaFxlh/szPEG/o3VcmCwl0N3E60XNb9YZZijew5eIs6fLjJuOPxQd9yEBaX2p/YfJtt49i4vYi38iH6/6w==",
       "requires": {
-        "cssnano-preset-simple": "1.2.2",
-        "postcss": "^7.0.32"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "7.0.35",
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1"
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
+        "cssnano-preset-simple": "^2.0.0"
       }
     },
     "cssnano-util-get-arguments": {
@@ -22236,7 +22166,9 @@
       }
     },
     "data-uri-to-buffer": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
     },
     "data-urls": {
       "version": "2.0.0",
@@ -23366,7 +23298,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.8"
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
     },
     "hsl-regex": {
       "version": "1.0.0"
@@ -25729,21 +25663,6 @@
         "type-check": "~0.3.2"
       }
     },
-    "line-column": {
-      "version": "1.0.2",
-      "requires": {
-        "isarray": "^1.0.0",
-        "isobject": "^2.0.0"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "2.1.0",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        }
-      }
-    },
     "lines-and-columns": {
       "version": "1.1.6"
     },
@@ -25806,7 +25725,9 @@
       "version": "4.6.2"
     },
     "lodash.sortby": {
-      "version": "4.7.0"
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
     },
     "lodash.startcase": {
       "version": "4.4.0"
@@ -26222,7 +26143,9 @@
       }
     },
     "mixme": {
-      "version": "0.4.0"
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mixme/-/mixme-0.5.1.tgz",
+      "integrity": "sha512-NaeZIckeBFT7i0XBEpGyFcAE0/bLcQ9MHErTpnU3bLWVE5WZbxG5Y3fDsMxYGifTo5khDA42OquXCC2ngKJB+g=="
     },
     "mkdirp": {
       "version": "0.5.5",
@@ -26418,7 +26341,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.1.22"
+      "version": "3.1.23",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -26446,14 +26371,16 @@
       "version": "1.4.0"
     },
     "next": {
-      "version": "10.1.3",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-10.2.0.tgz",
+      "integrity": "sha512-PKDKCSF7s82xudu3kQhOEaokxggpbLEWouEUtzP6OqV0YqKYHF+Ff+BFLycEem8ixtTM2M6ElN0VRJcskJfxPQ==",
       "requires": {
         "@babel/runtime": "7.12.5",
         "@hapi/accept": "5.0.1",
-        "@next/env": "10.1.3",
-        "@next/polyfill-module": "10.1.3",
-        "@next/react-dev-overlay": "10.1.3",
-        "@next/react-refresh-utils": "10.1.3",
+        "@next/env": "10.2.0",
+        "@next/polyfill-module": "10.2.0",
+        "@next/react-dev-overlay": "10.2.0",
+        "@next/react-refresh-utils": "10.2.0",
         "@opentelemetry/api": "0.14.0",
         "assert": "2.0.0",
         "ast-types": "0.13.2",
@@ -26465,7 +26392,7 @@
         "chokidar": "3.5.1",
         "constants-browserify": "1.0.0",
         "crypto-browserify": "3.12.0",
-        "cssnano-simple": "1.2.2",
+        "cssnano-simple": "2.0.0",
         "domain-browser": "4.19.0",
         "encoding": "0.1.13",
         "etag": "1.8.1",
@@ -26481,7 +26408,7 @@
         "p-limit": "3.1.0",
         "path-browserify": "1.0.1",
         "pnp-webpack-plugin": "1.6.4",
-        "postcss": "8.1.7",
+        "postcss": "8.2.13",
         "process": "0.11.10",
         "prop-types": "15.7.2",
         "querystring-es3": "0.2.1",
@@ -26532,18 +26459,6 @@
           "requires": {
             "yocto-queue": "^0.1.0"
           }
-        },
-        "postcss": {
-          "version": "8.1.7",
-          "requires": {
-            "colorette": "^1.2.1",
-            "line-column": "^1.0.2",
-            "nanoid": "^3.1.16",
-            "source-map": "^0.6.1"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1"
         },
         "supports-color": {
           "version": "8.1.1",
@@ -27067,7 +26982,9 @@
       }
     },
     "platform": {
-      "version": "1.3.6"
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
     },
     "pnp-webpack-plugin": {
       "version": "1.6.4",
@@ -27079,7 +26996,9 @@
       "version": "0.1.1"
     },
     "postcss": {
-      "version": "8.2.12",
+      "version": "8.2.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.13.tgz",
+      "integrity": "sha512-FCE5xLH+hjbzRdpbRb1IMCvPv9yZx2QnDarBEYSN0N0HYk+TcXsEhwdFcFb+SRWOKzKGErhIEbBK2ogyLdTtfQ==",
       "requires": {
         "colorette": "^1.2.2",
         "nanoid": "^3.1.22",
@@ -28260,7 +28179,9 @@
       "version": "16.13.1"
     },
     "react-refresh": {
-      "version": "0.8.3"
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
+      "integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg=="
     },
     "read-pkg": {
       "version": "5.2.0",
@@ -28947,7 +28868,9 @@
       "version": "1.0.0"
     },
     "shell-quote": {
-      "version": "1.7.2"
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
+      "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg=="
     },
     "shellwords": {
       "version": "0.1.1",
@@ -29171,12 +29094,16 @@
     },
     "stacktrace-parser": {
       "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.10.tgz",
+      "integrity": "sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==",
       "requires": {
         "type-fest": "^0.7.1"
       },
       "dependencies": {
         "type-fest": {
-          "version": "0.7.1"
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
+          "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg=="
         }
       }
     },
@@ -29224,9 +29151,11 @@
       }
     },
     "stream-transform": {
-      "version": "2.0.4",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-2.1.0.tgz",
+      "integrity": "sha512-bwQO+75rzQbug7e5OOHnOR3FgbJ0fCjHmDIdynkwUaFzleBXugGmv2dx3sX3aIHUQRLjrcisRPgN9BWl63uGgw==",
       "requires": {
-        "mixme": "^0.4.0"
+        "mixme": "^0.5.0"
       }
     },
     "strict-event-emitter": {
@@ -29642,6 +29571,8 @@
     },
     "tr46": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -30022,7 +29953,9 @@
       }
     },
     "webidl-conversions": {
-      "version": "4.0.2"
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
     },
     "whatwg-encoding": {
       "version": "1.0.5",
@@ -30035,6 +29968,8 @@
     },
     "whatwg-url": {
       "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
       "requires": {
         "lodash.sortby": "^4.7.0",
         "tr46": "^1.0.1",
@@ -30109,11 +30044,13 @@
           "dev": true
         },
         "postcss": {
-          "version": "8.2.12",
+          "version": "8.2.15",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.15.tgz",
+          "integrity": "sha512-2zO3b26eJD/8rb106Qu2o7Qgg52ND5HPjcyQiK2B98O388h43A448LCslC0dI2P97wCAQRJsFvwTRcXxTKds+Q==",
           "dev": true,
           "requires": {
             "colorette": "^1.2.2",
-            "nanoid": "^3.1.22",
+            "nanoid": "^3.1.23",
             "source-map": "^0.6.1"
           }
         },


### PR DESCRIPTION
This update removes the high severity and leaves the moderate. Running `npm audit fix --force` doesn't really make sense for our case (we're on a higher version of `microbundle`):
![image](https://user-images.githubusercontent.com/840935/117945809-fbc77900-b30e-11eb-8232-8d4be9943605.png)

FWIW, we're not affected by any of these "moderate" deps since we're not using that feature of `microbundle`