### PR TITLE
New Session events + strongly typed emitter + types improvements

### DIFF
--- a/examples/with-next.js/src/components/VideoWidget.tsx
+++ b/examples/with-next.js/src/components/VideoWidget.tsx
@@ -28,7 +28,7 @@ export const VideoWidget = ({
       experimental: true,
       // TODO:
       callerNumber: 'john@doe.com',
-    }) as any
+    })
   })
   const dispatch = useAppDispatch()
 

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -4,13 +4,14 @@ import { Emitter } from './utils/interfaces'
 import { SDKState } from './redux/interfaces'
 import { BaseComponentOptions } from './utils/interfaces'
 
-export class BaseComponent implements Emitter<BaseComponent> {
+export class BaseComponent<T extends string>
+  implements Emitter<T, BaseComponent<T>> {
   id = uuid()
 
   private _requests = new Map()
   private _destroyer?: () => void
 
-  constructor(public options: BaseComponentOptions<BaseComponent>) {}
+  constructor(public options: BaseComponentOptions<BaseComponent<T>, T>) {}
 
   set destroyer(d: () => void) {
     this._destroyer = d
@@ -24,23 +25,25 @@ export class BaseComponent implements Emitter<BaseComponent> {
     return this.options.emitter
   }
 
-  on(...params: Parameters<Emitter['on']>) {
+  on(...params: Parameters<Emitter<T, this>['on']>) {
     return this.emitter.on(...params)
   }
 
-  once(...params: Parameters<Emitter['once']>) {
+  once(...params: Parameters<Emitter<T, this>['once']>) {
     return this.emitter.once(...params)
   }
 
-  off(...params: Parameters<Emitter['off']>) {
+  off(...params: Parameters<Emitter<T, this>['off']>) {
     return this.emitter.off(...params)
   }
 
-  emit(...params: Parameters<Emitter['emit']>) {
+  emit(...params: Parameters<Emitter<T, this>['emit']>) {
     return this.emitter.emit(...params)
   }
 
-  removeAllListeners(...params: Parameters<Emitter['removeAllListeners']>) {
+  removeAllListeners(
+    ...params: Parameters<Emitter<T, this>['removeAllListeners']>
+  ) {
     return this.emitter.removeAllListeners(...params)
   }
 

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -4,14 +4,14 @@ import { Emitter } from './utils/interfaces'
 import { SDKState } from './redux/interfaces'
 import { BaseComponentOptions } from './utils/interfaces'
 
-export class BaseComponent<T extends string>
-  implements Emitter<T, BaseComponent<T>> {
+export class BaseComponent<EventType extends string>
+  implements Emitter<EventType, BaseComponent<EventType>> {
   id = uuid()
 
   private _requests = new Map()
   private _destroyer?: () => void
 
-  constructor(public options: BaseComponentOptions<BaseComponent<T>, T>) {}
+  constructor(public options: BaseComponentOptions<BaseComponent<EventType>, EventType>) {}
 
   set destroyer(d: () => void) {
     this._destroyer = d
@@ -25,24 +25,24 @@ export class BaseComponent<T extends string>
     return this.options.emitter
   }
 
-  on(...params: Parameters<Emitter<T, this>['on']>) {
+  on(...params: Parameters<Emitter<EventType, this>['on']>) {
     return this.emitter.on(...params)
   }
 
-  once(...params: Parameters<Emitter<T, this>['once']>) {
+  once(...params: Parameters<Emitter<EventType, this>['once']>) {
     return this.emitter.once(...params)
   }
 
-  off(...params: Parameters<Emitter<T, this>['off']>) {
+  off(...params: Parameters<Emitter<EventType, this>['off']>) {
     return this.emitter.off(...params)
   }
 
-  emit(...params: Parameters<Emitter<T, this>['emit']>) {
+  emit(...params: Parameters<Emitter<EventType, this>['emit']>) {
     return this.emitter.emit(...params)
   }
 
   removeAllListeners(
-    ...params: Parameters<Emitter<T, this>['removeAllListeners']>
+    ...params: Parameters<Emitter<EventType, this>['removeAllListeners']>
   ) {
     return this.emitter.removeAllListeners(...params)
   }

--- a/packages/core/src/SignalWire.ts
+++ b/packages/core/src/SignalWire.ts
@@ -14,23 +14,25 @@ export class SignalWire<T extends string> implements Emitter<T, SignalWire<T>> {
     return this.options.emitter
   }
 
-  on(...params: Parameters<Emitter<T>['on']>) {
+  on(...params: Parameters<Emitter<T, this>['on']>) {
     return this.emitter.on(...params)
   }
 
-  once(...params: Parameters<Emitter<T>['once']>) {
+  once(...params: Parameters<Emitter<T, this>['once']>) {
     return this.emitter.once(...params)
   }
 
-  off(...params: Parameters<Emitter<T>['off']>) {
+  off(...params: Parameters<Emitter<T, this>['off']>) {
     return this.emitter.off(...params)
   }
 
-  emit(...params: Parameters<Emitter<T>['emit']>) {
+  emit(...params: Parameters<Emitter<T, this>['emit']>) {
     return this.emitter.emit(...params)
   }
 
-  removeAllListeners(...params: Parameters<Emitter<T>['removeAllListeners']>) {
+  removeAllListeners(
+    ...params: Parameters<Emitter<T, this>['removeAllListeners']>
+  ) {
     return this.emitter.removeAllListeners(...params)
   }
 

--- a/packages/core/src/SignalWire.ts
+++ b/packages/core/src/SignalWire.ts
@@ -4,9 +4,9 @@ import { Emitter } from './utils/interfaces'
 import { AuthError } from './CustomErrors'
 import { BaseClientOptions } from './utils/interfaces'
 
-export class SignalWire<T extends string> implements Emitter<T, SignalWire<T>> {
+export class SignalWire<EventType extends string> implements Emitter<EventType, SignalWire<EventType>> {
   constructor(
-    public options: BaseClientOptions<SignalWire<T>, T>,
+    public options: BaseClientOptions<SignalWire<EventType>, EventType>,
     public store: Store
   ) {}
 
@@ -14,24 +14,24 @@ export class SignalWire<T extends string> implements Emitter<T, SignalWire<T>> {
     return this.options.emitter
   }
 
-  on(...params: Parameters<Emitter<T, this>['on']>) {
+  on(...params: Parameters<Emitter<EventType, this>['on']>) {
     return this.emitter.on(...params)
   }
 
-  once(...params: Parameters<Emitter<T, this>['once']>) {
+  once(...params: Parameters<Emitter<EventType, this>['once']>) {
     return this.emitter.once(...params)
   }
 
-  off(...params: Parameters<Emitter<T, this>['off']>) {
+  off(...params: Parameters<Emitter<EventType, this>['off']>) {
     return this.emitter.off(...params)
   }
 
-  emit(...params: Parameters<Emitter<T, this>['emit']>) {
+  emit(...params: Parameters<Emitter<EventType, this>['emit']>) {
     return this.emitter.emit(...params)
   }
 
   removeAllListeners(
-    ...params: Parameters<Emitter<T, this>['removeAllListeners']>
+    ...params: Parameters<Emitter<EventType, this>['removeAllListeners']>
   ) {
     return this.emitter.removeAllListeners(...params)
   }

--- a/packages/core/src/SignalWire.ts
+++ b/packages/core/src/SignalWire.ts
@@ -4,9 +4,9 @@ import { Emitter } from './utils/interfaces'
 import { AuthError } from './CustomErrors'
 import { BaseClientOptions } from './utils/interfaces'
 
-export class SignalWire implements Emitter<SignalWire> {
+export class SignalWire<T = string> implements Emitter<T, SignalWire<T>> {
   constructor(
-    public options: BaseClientOptions<SignalWire>,
+    public options: BaseClientOptions<T, SignalWire<T>>,
     public store: Store
   ) {}
 
@@ -14,23 +14,23 @@ export class SignalWire implements Emitter<SignalWire> {
     return this.options.emitter
   }
 
-  on(...params: Parameters<Emitter['on']>) {
+  on(...params: Parameters<Emitter<T>['on']>) {
     return this.emitter.on(...params)
   }
 
-  once(...params: Parameters<Emitter['once']>) {
+  once(...params: Parameters<Emitter<T>['once']>) {
     return this.emitter.once(...params)
   }
 
-  off(...params: Parameters<Emitter['off']>) {
+  off(...params: Parameters<Emitter<T>['off']>) {
     return this.emitter.off(...params)
   }
 
-  emit(...params: Parameters<Emitter['emit']>) {
+  emit(...params: Parameters<Emitter<T>['emit']>) {
     return this.emitter.emit(...params)
   }
 
-  removeAllListeners(...params: Parameters<Emitter['removeAllListeners']>) {
+  removeAllListeners(...params: Parameters<Emitter<T>['removeAllListeners']>) {
     return this.emitter.removeAllListeners(...params)
   }
 

--- a/packages/core/src/SignalWire.ts
+++ b/packages/core/src/SignalWire.ts
@@ -4,9 +4,9 @@ import { Emitter } from './utils/interfaces'
 import { AuthError } from './CustomErrors'
 import { BaseClientOptions } from './utils/interfaces'
 
-export class SignalWire<T = string> implements Emitter<T, SignalWire<T>> {
+export class SignalWire<T extends string> implements Emitter<T, SignalWire<T>> {
   constructor(
-    public options: BaseClientOptions<T, SignalWire<T>>,
+    public options: BaseClientOptions<SignalWire<T>, T>,
     public store: Store
   ) {}
 

--- a/packages/core/src/redux/actions.ts
+++ b/packages/core/src/redux/actions.ts
@@ -1,10 +1,10 @@
 import { createAction } from '@reduxjs/toolkit'
-import { JSONRPCRequest, SessionAuthError } from '../utils/interfaces'
 import {
-  ExecuteActionParams,
+  JSONRPCRequest,
+  SessionAuthError,
   SessionEvents,
-  SocketCloseParams,
-} from './interfaces'
+} from '../utils/interfaces'
+import { ExecuteActionParams, SocketCloseParams } from './interfaces'
 
 export const initAction = createAction('swSdk/init')
 export const destroyAction = createAction('swSdk/destroy')

--- a/packages/core/src/redux/actions.ts
+++ b/packages/core/src/redux/actions.ts
@@ -1,6 +1,10 @@
 import { createAction } from '@reduxjs/toolkit'
 import { JSONRPCRequest, SessionAuthError } from '../utils/interfaces'
-import { ExecuteActionParams, SocketCloseParams } from './interfaces'
+import {
+  ExecuteActionParams,
+  SessionEvents,
+  SocketCloseParams,
+} from './interfaces'
 
 export const initAction = createAction('swSdk/init')
 export const destroyAction = createAction('swSdk/destroy')
@@ -19,4 +23,15 @@ export const socketClosed = createAction<SocketCloseParams>('socket/closed')
 export const socketError = createAction('socket/error')
 export const socketMessage = createAction<JSONRPCRequest, string>(
   'socket/message'
+)
+
+// TODO: define if we need/want to send a payload with these events.
+export const sessionConnected = createAction<void, SessionEvents>(
+  'session.connected'
+)
+export const sessionDisconnected = createAction<void, SessionEvents>(
+  'session.disconnected'
+)
+export const sessionReconnecting = createAction<void, SessionEvents>(
+  'session.reconnecting'
 )

--- a/packages/core/src/redux/connect.ts
+++ b/packages/core/src/redux/connect.ts
@@ -11,7 +11,7 @@ interface Connect<T> {
 }
 type ReduxComponentKeys = keyof ReduxComponent
 
-export const connect = <T extends { id: string; destroyer: any }>(
+export const connect = <T extends { id: string; destroyer: () => void }>(
   options: Connect<T>
 ) => {
   const { onStateChangeListeners = {}, store, Component } = options

--- a/packages/core/src/redux/connect.ts
+++ b/packages/core/src/redux/connect.ts
@@ -1,18 +1,17 @@
 import { Store } from 'redux'
 import { ReduxComponent } from './interfaces'
-import { BaseComponent } from '../BaseComponent'
 import { componentActions } from './features'
 import { getComponent } from './features/component/componentSelectors'
 
 type ConnectEventHandler = (component: ReduxComponent) => any
-interface Connect<T extends typeof BaseComponent> {
+interface Connect<T> {
   onStateChangeListeners: Record<string, string | ConnectEventHandler>
   store: Store
-  Component: T
+  Component: new (o: any) => T
 }
 type ReduxComponentKeys = keyof ReduxComponent
 
-export const connect = <T extends typeof BaseComponent>(
+export const connect = <T extends { id: string; destroyer: any }>(
   options: Connect<T>
 ) => {
   const { onStateChangeListeners = {}, store, Component } = options

--- a/packages/core/src/redux/features/session/sessionSlice.test.ts
+++ b/packages/core/src/redux/features/session/sessionSlice.test.ts
@@ -18,7 +18,7 @@ describe('SessionState Tests', () => {
       iceServers: bladeConnectResultVRT.result?.iceServers,
       authStatus: 'authorized',
       authError: undefined,
-      socketStatus: 'open',
+      status: 'connected',
     })
   })
 

--- a/packages/core/src/redux/features/session/sessionSlice.ts
+++ b/packages/core/src/redux/features/session/sessionSlice.ts
@@ -25,7 +25,7 @@ const sessionSlice = createSlice({
       state.protocol = payload?.result?.protocol ?? ''
       state.iceServers = payload?.result?.iceServers ?? []
     },
-    socketStatusChange: (state, { payload }: PayloadAction<SessionStatus>) => {
+    statusChange: (state, { payload }: PayloadAction<SessionStatus>) => {
       state.status = payload
     },
   },

--- a/packages/core/src/redux/features/session/sessionSlice.ts
+++ b/packages/core/src/redux/features/session/sessionSlice.ts
@@ -3,7 +3,7 @@ import { SessionState } from '../../interfaces'
 import {
   IBladeConnectResult,
   SessionAuthError,
-  SocketStatus,
+  SessionStatus,
 } from '../../../utils/interfaces'
 import { destroyAction, authError } from '../../actions'
 
@@ -12,7 +12,7 @@ export const initialSessionState: Readonly<SessionState> = {
   iceServers: [],
   authStatus: 'unknown',
   authError: undefined,
-  socketStatus: 'unknown',
+  status: 'unknown',
 }
 
 const sessionSlice = createSlice({
@@ -21,12 +21,12 @@ const sessionSlice = createSlice({
   reducers: {
     connected: (state, { payload }: PayloadAction<IBladeConnectResult>) => {
       state.authStatus = 'authorized'
-      state.socketStatus = 'open'
+      state.status = 'connected'
       state.protocol = payload?.result?.protocol ?? ''
       state.iceServers = payload?.result?.iceServers ?? []
     },
-    socketStatusChange: (state, { payload }: PayloadAction<SocketStatus>) => {
-      state.socketStatus = payload
+    socketStatusChange: (state, { payload }: PayloadAction<SessionStatus>) => {
+      state.status = payload
     },
   },
   extraReducers: (builder) => {

--- a/packages/core/src/redux/interfaces.ts
+++ b/packages/core/src/redux/interfaces.ts
@@ -4,7 +4,7 @@ import {
   JSONRPCResponse,
   SessionAuthError,
   SessionAuthStatus,
-  SocketStatus,
+  SessionStatus,
 } from '../utils/interfaces'
 
 interface SWComponent {
@@ -45,8 +45,10 @@ export interface SessionState {
   iceServers?: RTCIceServer[]
   authStatus: SessionAuthStatus
   authError?: SessionAuthError
-  socketStatus: SocketStatus
+  status: SessionStatus
 }
+
+export type SessionEvents = `session.${SessionStatus}`
 
 export interface SDKState {
   components: ComponentState

--- a/packages/core/src/redux/interfaces.ts
+++ b/packages/core/src/redux/interfaces.ts
@@ -48,8 +48,6 @@ export interface SessionState {
   status: SessionStatus
 }
 
-export type SessionEvents = `session.${SessionStatus}`
-
 export interface SDKState {
   components: ComponentState
   session: SessionState

--- a/packages/core/src/redux/rootSaga.test.ts
+++ b/packages/core/src/redux/rootSaga.test.ts
@@ -20,7 +20,7 @@ describe('socketClosedWorker', () => {
       sessionChannel,
       payload: { code: 1006, reason: '' },
     })
-      .put(sessionActions.socketStatusChange('reconnecting'))
+      .put(sessionActions.statusChange('reconnecting'))
       .call(session.connect)
       .run(timeout)
   })
@@ -40,7 +40,7 @@ describe('socketClosedWorker', () => {
         sessionChannel,
         payload: { code: 1002, reason: '' },
       })
-        .put(sessionActions.socketStatusChange('disconnected'))
+        .put(sessionActions.statusChange('disconnected'))
         .put(pubSubChannel, sessionDisconnected())
         .run(),
       expectSaga(socketClosedWorker, {
@@ -49,7 +49,7 @@ describe('socketClosedWorker', () => {
         sessionChannel,
         payload: { code: 1000, reason: '' },
       })
-        .put(sessionActions.socketStatusChange('disconnected'))
+        .put(sessionActions.statusChange('disconnected'))
         .put(pubSubChannel, sessionDisconnected())
         .run(),
       expectSaga(socketClosedWorker, {
@@ -58,7 +58,7 @@ describe('socketClosedWorker', () => {
         sessionChannel,
         payload: { code: 1020, reason: '' },
       })
-        .put(sessionActions.socketStatusChange('disconnected'))
+        .put(sessionActions.statusChange('disconnected'))
         .put(pubSubChannel, sessionDisconnected())
         .run(),
     ])

--- a/packages/core/src/redux/rootSaga.test.ts
+++ b/packages/core/src/redux/rootSaga.test.ts
@@ -2,11 +2,7 @@ import { channel, eventChannel } from 'redux-saga'
 import { expectSaga } from 'redux-saga-test-plan'
 import { socketClosedWorker } from './rootSaga'
 import { sessionActions } from './features'
-import {
-  sessionConnected,
-  sessionDisconnected,
-  sessionReconnecting,
-} from './actions'
+import { sessionDisconnected } from './actions'
 
 describe('socketClosedWorker', () => {
   it('should try to reconnect when code >= 1006 && code <= 1014', async () => {

--- a/packages/core/src/redux/rootSaga.test.ts
+++ b/packages/core/src/redux/rootSaga.test.ts
@@ -2,6 +2,11 @@ import { channel, eventChannel } from 'redux-saga'
 import { expectSaga } from 'redux-saga-test-plan'
 import { socketClosedWorker } from './rootSaga'
 import { sessionActions } from './features'
+import {
+  sessionConnected,
+  sessionDisconnected,
+  sessionReconnecting,
+} from './actions'
 
 describe('socketClosedWorker', () => {
   it('should try to reconnect when code >= 1006 && code <= 1014', async () => {
@@ -39,11 +44,8 @@ describe('socketClosedWorker', () => {
         sessionChannel,
         payload: { code: 1002, reason: '' },
       })
-        .put(sessionActions.socketStatusChange('closed'))
-        .put(pubSubChannel, {
-          type: 'socket.closed',
-          payload: {},
-        })
+        .put(sessionActions.socketStatusChange('disconnected'))
+        .put(pubSubChannel, sessionDisconnected())
         .run(),
       expectSaga(socketClosedWorker, {
         session,
@@ -51,11 +53,8 @@ describe('socketClosedWorker', () => {
         sessionChannel,
         payload: { code: 1000, reason: '' },
       })
-        .put(sessionActions.socketStatusChange('closed'))
-        .put(pubSubChannel, {
-          type: 'socket.closed',
-          payload: {},
-        })
+        .put(sessionActions.socketStatusChange('disconnected'))
+        .put(pubSubChannel, sessionDisconnected())
         .run(),
       expectSaga(socketClosedWorker, {
         session,
@@ -63,11 +62,8 @@ describe('socketClosedWorker', () => {
         sessionChannel,
         payload: { code: 1020, reason: '' },
       })
-        .put(sessionActions.socketStatusChange('closed'))
-        .put(pubSubChannel, {
-          type: 'socket.closed',
-          payload: {},
-        })
+        .put(sessionActions.socketStatusChange('disconnected'))
+        .put(pubSubChannel, sessionDisconnected())
         .run(),
     ])
   })

--- a/packages/core/src/redux/rootSaga.ts
+++ b/packages/core/src/redux/rootSaga.ts
@@ -84,13 +84,13 @@ export function* socketClosedWorker({
    * @see https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent
    */
   if (code >= 1006 && code <= 1014) {
-    yield put(sessionActions.socketStatusChange('reconnecting'))
+    yield put(sessionActions.statusChange('reconnecting'))
     yield put(pubSubChannel, sessionReconnecting())
     yield delay(Math.random() * 2000)
     yield call(session.connect)
   } else {
     sessionChannel.close()
-    yield put(sessionActions.socketStatusChange('disconnected'))
+    yield put(sessionActions.statusChange('disconnected'))
     yield put(pubSubChannel, sessionDisconnected())
   }
 }

--- a/packages/core/src/utils/EventEmitter.ts
+++ b/packages/core/src/utils/EventEmitter.ts
@@ -3,7 +3,8 @@ import { Emitter, UserOptions } from './interfaces'
 export const EventEmitter = () => {
   const _queue: { [key: string]: Function[] } = {}
   const _uniqueKey = Symbol.for('sw-once-key')
-  return new (class BaseEventEmitter implements Emitter<BaseEventEmitter> {
+  return new (class BaseEventEmitter
+    implements Emitter<string, BaseEventEmitter> {
     on(eventName: string, handler: Function, once = false) {
       if (!_queue[eventName]) {
         _queue[eventName] = []
@@ -80,7 +81,9 @@ const REQUIRED_EMITTER_METHODS = [
  * Checks the shape of the emitter at runtime. This is useful for when
  * the user is using the SDK without TS
  */
-export const assertEventEmitter = (emitter: unknown): emitter is Emitter => {
+export const assertEventEmitter = <T>(
+  emitter: unknown
+): emitter is Emitter<T> => {
   if (
     emitter &&
     typeof emitter === 'object' &&
@@ -92,11 +95,13 @@ export const assertEventEmitter = (emitter: unknown): emitter is Emitter => {
   return false
 }
 
-export const getEventEmitter = <T = {}>(userOptions: UserOptions) => {
+export const getEventEmitter = <T = string, Instance = {}>(
+  userOptions: UserOptions
+) => {
   if (!userOptions.emitter) {
-    return (EventEmitter() as unknown) as Emitter<T>
-  } else if (assertEventEmitter(userOptions.emitter)) {
-    return userOptions.emitter as Emitter<T>
+    return (EventEmitter() as unknown) as Emitter<T, Instance>
+  } else if (assertEventEmitter<T>(userOptions.emitter)) {
+    return (userOptions.emitter as unknown) as Emitter<T, Instance>
   }
   // TODO: In future versions we can narrow this error a bit more and
   // give the user more info about which method they are missing as

--- a/packages/core/src/utils/constants.ts
+++ b/packages/core/src/utils/constants.ts
@@ -44,6 +44,7 @@ export enum VertoMethod {
   Announce = 'verto.announce',
 }
 
+// TODO: do we still need these of if we can just `CallState` instead.
 export enum SwWebRTCCallState {
   New = 'new',
   Requesting = 'requesting',

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -133,7 +133,7 @@ export type RoomEvent =
   | 'subscribed'
   | 'updated'
 
-export type CallEvent =
+export type CallState =
   | 'active'
   | 'answering'
   | 'destroy'
@@ -154,7 +154,7 @@ export type CallEvent =
 export type CallEvents =
   | `layout.${LayoutEvent}`
   | `room.${RoomEvent}`
-  | CallEvent
+  | CallState
 
 export type SessionAuthError = {
   code: number

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -137,6 +137,7 @@ export type RoomEvent =
 export type MemberEvent =
   | 'joined'
   | 'left'
+  | 'updated'
 
 export type CallState =
   | 'active'

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -42,18 +42,23 @@ export interface SessionOptions {
   autoConnect?: boolean
 }
 
-export interface UserOptions<EventType = string, T = {}>
+export interface UserOptions<T = {}, EventType extends string = string>
   extends SessionOptions {
   devTools?: boolean
   emitter?: Emitter<EventType, T>
 }
 
-export interface BaseClientOptions<EventType = string, T = {}>
-  extends UserOptions<EventType, T> {
+export interface BaseClientOptions<
+  T = {},
+  EventType extends string = ClientEvents
+> extends UserOptions<T, EventType> {
   emitter: Emitter<EventType, T>
 }
 
-export interface BaseComponentOptions<EventType = string, T = {}> {
+export interface BaseComponentOptions<
+  T = {},
+  EventType extends string = string
+> {
   store: Store
   emitter: Emitter<EventType, T>
 }
@@ -114,6 +119,9 @@ export type SessionStatus =
 
 export type SessionEvents = `session.${SessionStatus}`
 
+/**
+ * List of all the events the client can listen to.
+ */
 export type ClientEvents = SessionEvents
 
 export type SessionAuthError = {

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -124,6 +124,38 @@ export type SessionEvents = `session.${SessionStatus}`
  */
 export type ClientEvents = SessionEvents
 
+export type LayoutEvent = 'changed'
+
+// prettier-ignore
+export type RoomEvent =
+  | 'ended'
+  | 'started'
+  | 'subscribed'
+  | 'updated'
+
+export type CallEvent =
+  | 'active'
+  | 'answering'
+  | 'destroy'
+  | 'early'
+  | 'hangup'
+  | 'held'
+  | 'new'
+  | 'purge'
+  | 'recovering'
+  | 'requesting'
+  | 'ringing'
+  | 'track'
+  | 'trying'
+
+/**
+ * List of all the events the call can listen to
+ */
+export type CallEvents =
+  | `layout.${LayoutEvent}`
+  | `room.${RoomEvent}`
+  | CallEvent
+
 export type SessionAuthError = {
   code: number
   error: string

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -133,6 +133,11 @@ export type RoomEvent =
   | 'subscribed'
   | 'updated'
 
+// prettier-ignore
+export type MemberEvent =
+  | 'joined'
+  | 'left'
+
 export type CallState =
   | 'active'
   | 'answering'
@@ -153,6 +158,7 @@ export type CallState =
  */
 export type CallEvents =
   | `layout.${LayoutEvent}`
+  | `member.${MemberEvent}`
   | `room.${RoomEvent}`
   | CallState
 

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -104,7 +104,11 @@ export type SessionAuthStatus =
   | 'unauthorized'
 
 // TODO: define proper list of statuses
-export type SocketStatus = 'unknown' | 'reconnecting' | 'open' | 'closed'
+export type SessionStatus =
+  | 'unknown'
+  | 'reconnecting'
+  | 'connected'
+  | 'disconnected'
 
 export type SessionAuthError = {
   code: number

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -1,12 +1,12 @@
 import { Store } from 'redux'
 import { Session } from '../Session'
 
-export interface Emitter<T = {}> {
-  on(eventName: string, handler: Function, once?: boolean): T
-  once(eventName: string, handler: Function): T
-  off(eventName: string, handler?: Function): T
-  emit(eventName: string, ...args: any[]): boolean
-  removeAllListeners(): T
+export interface Emitter<EventType, Instance = {}> {
+  on(eventName: EventType, handler: Function, once?: boolean): Instance
+  once(eventName: EventType, handler: Function): Instance
+  off(eventName: EventType, handler?: Function): Instance
+  emit(eventName: EventType, ...args: any[]): boolean
+  removeAllListeners(): Instance
 }
 
 type JSONRPCParams = {
@@ -42,18 +42,20 @@ export interface SessionOptions {
   autoConnect?: boolean
 }
 
-export interface UserOptions<T = {}> extends SessionOptions {
+export interface UserOptions<EventType = string, T = {}>
+  extends SessionOptions {
   devTools?: boolean
-  emitter?: Emitter<T>
+  emitter?: Emitter<EventType, T>
 }
 
-export interface BaseClientOptions<T = {}> extends UserOptions<T> {
-  emitter: Emitter<T>
+export interface BaseClientOptions<EventType = string, T = {}>
+  extends UserOptions<EventType, T> {
+  emitter: Emitter<EventType, T>
 }
 
-export interface BaseComponentOptions<T = {}> {
+export interface BaseComponentOptions<EventType = string, T = {}> {
   store: Store
-  emitter: Emitter<T>
+  emitter: Emitter<EventType, T>
 }
 
 export interface SessionRequestObject {
@@ -109,6 +111,10 @@ export type SessionStatus =
   | 'reconnecting'
   | 'connected'
   | 'disconnected'
+
+export type SessionEvents = `session.${SessionStatus}`
+
+export type ClientEvents = SessionEvents
 
 export type SessionAuthError = {
   code: number

--- a/packages/web/examples/ts-vanilla/index.ts
+++ b/packages/web/examples/ts-vanilla/index.ts
@@ -13,8 +13,9 @@ window._makeClient = async ({ token, emitter }) => {
       autoConnect: false,
       emitter,
     })
-    client.on('socket.error', console.warn)
-    client.on('socket.closed', console.warn)
+
+    client.on('session.disconnected', console.warn)
+    client.on('session.connected', console.warn)
 
     // @ts-ignore
     window.__client = client

--- a/packages/web/src/Client.ts
+++ b/packages/web/src/Client.ts
@@ -2,7 +2,7 @@ import { SignalWire, connect } from '@signalwire/core'
 import { Call } from '@signalwire/webrtc'
 import { videoElementFactory } from './utils/videoElementFactory'
 
-export class Client extends SignalWire {
+export class Client<T = string> extends SignalWire<T> {
   get rooms() {
     return {
       // TODO: use CallOptions interface here

--- a/packages/web/src/Client.ts
+++ b/packages/web/src/Client.ts
@@ -1,6 +1,5 @@
-import { SignalWire, connect } from '@signalwire/core'
+import { SignalWire, ClientEvents, connect } from '@signalwire/core'
 import { Call } from '@signalwire/webrtc'
-import { ClientEvents } from '@signalwire/core'
 import { videoElementFactory } from './utils/videoElementFactory'
 
 export class Client<EventType extends string = ClientEvents> extends SignalWire<EventType> {

--- a/packages/web/src/Client.ts
+++ b/packages/web/src/Client.ts
@@ -1,6 +1,6 @@
 import { SignalWire, connect } from '@signalwire/core'
 import { Call } from '@signalwire/webrtc'
-import { ClientEvents } from 'packages/core/dist/core/src/core/src'
+import { ClientEvents } from '@signalwire/core'
 import { videoElementFactory } from './utils/videoElementFactory'
 
 export class Client<T extends string = ClientEvents> extends SignalWire<T> {

--- a/packages/web/src/Client.ts
+++ b/packages/web/src/Client.ts
@@ -3,7 +3,7 @@ import { Call } from '@signalwire/webrtc'
 import { ClientEvents } from '@signalwire/core'
 import { videoElementFactory } from './utils/videoElementFactory'
 
-export class Client<T extends string = ClientEvents> extends SignalWire<T> {
+export class Client<EventType extends string = ClientEvents> extends SignalWire<EventType> {
   get rooms() {
     return {
       // TODO: use CallOptions interface here

--- a/packages/web/src/Client.ts
+++ b/packages/web/src/Client.ts
@@ -1,8 +1,9 @@
 import { SignalWire, connect } from '@signalwire/core'
 import { Call } from '@signalwire/webrtc'
+import { ClientEvents } from 'packages/core/dist/core/src/core/src'
 import { videoElementFactory } from './utils/videoElementFactory'
 
-export class Client<T = string> extends SignalWire<T> {
+export class Client<T extends string = ClientEvents> extends SignalWire<T> {
   get rooms() {
     return {
       // TODO: use CallOptions interface here

--- a/packages/web/src/createClient.ts
+++ b/packages/web/src/createClient.ts
@@ -7,13 +7,8 @@ import {
 } from '@signalwire/core'
 import { Client } from './Client'
 
-type ClientEvents = 'session.connected' | 'session.disconnected'
-
 export const createClient = async (userOptions: UserOptions) => {
-  const baseUserOptions: BaseClientOptions<
-    ClientEvents,
-    Client<ClientEvents>
-  > = {
+  const baseUserOptions: BaseClientOptions<Client> = {
     ...userOptions,
     emitter: getEventEmitter(userOptions),
   }

--- a/packages/web/src/createClient.ts
+++ b/packages/web/src/createClient.ts
@@ -7,8 +7,13 @@ import {
 } from '@signalwire/core'
 import { Client } from './Client'
 
+type ClientEvents = 'session.connected' | 'session.disconnected'
+
 export const createClient = async (userOptions: UserOptions) => {
-  const baseUserOptions: BaseClientOptions<Client> = {
+  const baseUserOptions: BaseClientOptions<
+    ClientEvents,
+    Client<ClientEvents>
+  > = {
     ...userOptions,
     emitter: getEventEmitter(userOptions),
   }

--- a/packages/web/src/createRTCSession.ts
+++ b/packages/web/src/createRTCSession.ts
@@ -1,4 +1,4 @@
-import { UserOptions, BaseComponent } from '@signalwire/core'
+import { UserOptions } from '@signalwire/core'
 import { createClient } from './createClient'
 import { videoElementFactory } from './utils/videoElementFactory'
 
@@ -10,9 +10,7 @@ interface CreateRTCSessionOptions extends UserOptions {
   applyLocalVideoOverlay?: boolean
 }
 
-export const createRTCSession = (
-  roomOptions: CreateRTCSessionOptions
-): Promise<BaseComponent> => {
+export const createRTCSession = (roomOptions: CreateRTCSessionOptions) => {
   return new Promise(async (resolve, _reject) => {
     const {
       audio = true,

--- a/packages/webrtc/src/BaseCall.ts
+++ b/packages/webrtc/src/BaseCall.ts
@@ -39,17 +39,17 @@ const ROOM_EVENTS = [
 type BaseCallOptions<T extends string> = CallOptions &
   BaseComponentOptions<BaseCall<T>, T>
 export class BaseCall<
-  Events extends string = CallEvents
-> extends BaseComponent<Events> {
+  EventType extends string = CallEvents
+> extends BaseComponent<EventType> {
   public nodeId = ''
   public direction: Direction
-  public peer: RTCPeer<Events>
-  public options: BaseCallOptions<Events>
+  public peer: RTCPeer<EventType>
+  public options: BaseCallOptions<EventType>
   public cause: string
   public causeCode: string
   public gotEarly = false
-  public screenShare?: BaseCall<Events>
-  public secondSource?: BaseCall<Events>
+  public screenShare?: BaseCall<EventType>
+  public secondSource?: BaseCall<EventType>
   public doReinvite = false
   public isDirect = false
   public videoElements: HTMLVideoElement[] = []
@@ -65,7 +65,7 @@ export class BaseCall<
   private _roomSessionId: string
   private _memberId: string
 
-  constructor(options: BaseCallOptions<Events>) {
+  constructor(options: BaseCallOptions<EventType>) {
     super(options)
 
     const iceServers =
@@ -491,7 +491,7 @@ export class BaseCall<
       `Call ${this.id} state change from ${this.prevState} to ${this.state}`
     )
 
-    this.emit(this.state as Events, this)
+    this.emit(this.state as EventType, this)
 
     switch (state) {
       case SwWebRTCCallState.Purge: {

--- a/packages/webrtc/src/BaseCall.ts
+++ b/packages/webrtc/src/BaseCall.ts
@@ -10,6 +10,7 @@ import {
   ConferenceMethod,
   selectors,
   BaseComponentOptions,
+  CallEvents,
 } from '@signalwire/core'
 import RTCPeer from './RTCPeer'
 import { DEFAULT_CALL_OPTIONS, PeerType, Direction } from './utils/constants'
@@ -35,18 +36,20 @@ const ROOM_EVENTS = [
   'layout.changed',
 ]
 
-type BaseCallOptions = CallOptions & BaseComponentOptions<BaseCall>
-
-export class BaseCall extends BaseComponent {
+type BaseCallOptions<T extends string> = CallOptions &
+  BaseComponentOptions<BaseCall<T>, T>
+export class BaseCall<
+  Events extends string = CallEvents
+> extends BaseComponent<Events> {
   public nodeId = ''
   public direction: Direction
-  public peer: RTCPeer
-  public options: BaseCallOptions
+  public peer: RTCPeer<Events>
+  public options: BaseCallOptions<Events>
   public cause: string
   public causeCode: string
   public gotEarly = false
-  public screenShare?: BaseCall
-  public secondSource?: BaseCall
+  public screenShare?: BaseCall<Events>
+  public secondSource?: BaseCall<Events>
   public doReinvite = false
   public isDirect = false
   public videoElements: HTMLVideoElement[] = []
@@ -62,7 +65,7 @@ export class BaseCall extends BaseComponent {
   private _roomSessionId: string
   private _memberId: string
 
-  constructor(options: BaseCallOptions) {
+  constructor(options: BaseCallOptions<Events>) {
     super(options)
 
     const iceServers =
@@ -488,7 +491,7 @@ export class BaseCall extends BaseComponent {
       `Call ${this.id} state change from ${this.prevState} to ${this.state}`
     )
 
-    this.emit(this.state, this)
+    this.emit(this.state as Events, this)
 
     switch (state) {
       case SwWebRTCCallState.Purge: {

--- a/packages/webrtc/src/Call.ts
+++ b/packages/webrtc/src/Call.ts
@@ -1,6 +1,7 @@
+import { CallEvents } from '@signalwire/core'
 import { BaseCall } from './BaseCall'
 
-export class Call extends BaseCall {
+export class Call<T extends string = CallEvents> extends BaseCall<T> {
   desktopOnlyMethod() {
     console.debug('Desktop Method')
   }

--- a/packages/webrtc/src/RTCPeer.ts
+++ b/packages/webrtc/src/RTCPeer.ts
@@ -19,14 +19,14 @@ import {
 } from './utils/webrtcHelpers'
 import { CallOptions } from './utils/interfaces'
 
-export default class RTCPeer {
+export default class RTCPeer<T extends string> {
   public instance: RTCPeerConnection
 
   private options: CallOptions
   private _iceTimeout: any
   private _negotiating = false
 
-  constructor(public call: BaseCall, public type: PeerType) {
+  constructor(public call: BaseCall<T>, public type: PeerType) {
     this.options = call.options
     logger.info('New Peer with type:', this.type, 'Options:', this.options)
 
@@ -331,7 +331,7 @@ export default class RTCPeer {
     }
 
     this.instance.addEventListener('track', (event: RTCTrackEvent) => {
-      this.call.emit('track', event)
+      this.call.emit('track' as T, event)
       if (this.hasExperimentalFlag) {
         // this._buildMediaElementByTrack(event)
         // const notification = { type: 'trackAdd', event }
@@ -493,7 +493,7 @@ export default class RTCPeer {
     }
     if (event.candidate) {
       logger.debug('RTCPeer Candidate:', event.candidate)
-      this.call.emit('icecandidate', event)
+      this.call.emit('icecandidate' as T, event)
     } else {
       this._sdpReady()
     }


### PR DESCRIPTION
The code in this changeset includes:

* Added ability to emit the session status (`'unknown' | 'reconnecting' | 'connected'  | 'disconnected'`) and removed the internal lower level `socket.*` events (as per our discussion @edolix)
* Emitter can now be strongly typed so both `Client` and `Call` accept a union type. Each `createClient/createCall` will also have the option to overwrite/extends these base types. (related #85)
* Fixed issue with `connect` always returning `BaseComponent`.