### PR TITLE
Rename "conference." with "video." in RPC methods

### DIFF
--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -282,25 +282,32 @@ export type BladeBroadcastParams =
   | MessagingEvent
 
 /**
- * List of all conference methods
+ * List of all room member methods
  */
-export type ConferenceMethod =
-  | 'conference.member.audio_mute'
-  | 'conference.member.audio_unmute'
-  | 'conference.member.video_mute'
-  | 'conference.member.video_unmute'
-  | 'conference.member.deaf'
-  | 'conference.member.undeaf'
-  | 'conference.member.volume.in.set'
-  | 'conference.member.volume.out.set'
-  | 'conference.member.energy.set'
+type RoomMemberMethod =
+  | 'member.audio_mute'
+  | 'member.audio_unmute'
+  | 'member.video_mute'
+  | 'member.video_unmute'
+  | 'member.deaf'
+  | 'member.undeaf'
+  | 'member.volume.in.set'
+  | 'member.volume.out.set'
+  | 'member.energy.set'
   // TODO: check kick
-  | 'conference.member.kick'
+  | 'member.kick'
+
+/**
+ * List of all room member methods
+ */
+// prettier-ignore
+export type RoomMethod =
+  | `video.${RoomMemberMethod}`
 
 /**
  * List of all available blade.execute methods
  */
 // prettier-ignore
 export type BladeExecuteMethod =
-  | ConferenceMethod
+  | RoomMethod
   | 'video.message'

--- a/packages/webrtc/src/BaseCall.ts
+++ b/packages/webrtc/src/BaseCall.ts
@@ -7,7 +7,7 @@ import {
   BaseComponent,
   SwWebRTCCallState,
   VertoMethod,
-  ConferenceMethod,
+  RoomMethod,
   selectors,
   BaseComponentOptions,
   CallEvents,
@@ -554,49 +554,49 @@ export class BaseCall extends BaseComponent<CallEvents> {
 
   public audioMute({ memberId }: MemberCommandParams = {}) {
     return this._memberCommand({
-      method: 'conference.member.audio_mute',
+      method: 'video.member.audio_mute',
       memberId,
     })
   }
 
   public audioUnmute({ memberId }: MemberCommandParams = {}) {
     return this._memberCommand({
-      method: 'conference.member.audio_unmute',
+      method: 'video.member.audio_unmute',
       memberId,
     })
   }
 
   public videoMute({ memberId }: MemberCommandParams = {}) {
     return this._memberCommand({
-      method: 'conference.member.video_mute',
+      method: 'video.member.video_mute',
       memberId,
     })
   }
 
   public videoUnmute({ memberId }: MemberCommandParams = {}) {
     return this._memberCommand({
-      method: 'conference.member.video_unmute',
+      method: 'video.member.video_unmute',
       memberId,
     })
   }
 
   public deaf({ memberId }: MemberCommandParams = {}) {
     return this._memberCommand({
-      method: 'conference.member.deaf',
+      method: 'video.member.deaf',
       memberId,
     })
   }
 
   public undeaf({ memberId }: MemberCommandParams = {}) {
     return this._memberCommand({
-      method: 'conference.member.undeaf',
+      method: 'video.member.undeaf',
       memberId,
     })
   }
 
   public setSpeakerVolume({ memberId, value }: MemberCommandWithValueParams) {
     return this._memberCommand({
-      method: 'conference.member.volume.in.set',
+      method: 'video.member.volume.in.set',
       memberId,
       value,
     })
@@ -607,7 +607,7 @@ export class BaseCall extends BaseComponent<CallEvents> {
     value,
   }: MemberCommandWithValueParams) {
     return this._memberCommand({
-      method: 'conference.member.volume.out.set',
+      method: 'video.member.volume.out.set',
       memberId,
       value,
     })
@@ -615,7 +615,7 @@ export class BaseCall extends BaseComponent<CallEvents> {
 
   public setNoiseGateValue({ memberId, value }: MemberCommandWithValueParams) {
     return this._memberCommand({
-      method: 'conference.member.energy.set',
+      method: 'video.member.energy.set',
       memberId,
       value,
     })
@@ -626,7 +626,7 @@ export class BaseCall extends BaseComponent<CallEvents> {
       throw new TypeError('Invalid or missing "memberId" argument')
     }
     return this._memberCommand({
-      method: 'conference.member.kick',
+      method: 'video.member.kick',
       memberId,
     })
   }
@@ -636,7 +636,7 @@ export class BaseCall extends BaseComponent<CallEvents> {
     memberId,
     ...rest
   }: {
-    method: ConferenceMethod
+    method: RoomMethod
     memberId?: string
     [key: string]: unknown
   }) {


### PR DESCRIPTION
Yesterday we decided to rename the blade.execute methods to be consistent with the scopes so

`conference.member.audio_mute` => `video.member.audio_mute`

