### PR TITLE
Drop SwWebRTCCallState enum

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,7 +23,7 @@ export {
 
 export * from './RPCMessages'
 export * from './utils/interfaces'
-export { SwWebRTCCallState, VertoMethod } from './utils/constants'
+export { VertoMethod } from './utils/constants'
 export * from './CustomErrors'
 
 export const selectors = {

--- a/packages/core/src/redux/features/session/sessionSaga.ts
+++ b/packages/core/src/redux/features/session/sessionSaga.ts
@@ -11,11 +11,7 @@ import {
 import { ExecuteActionParams, WebRTCCall } from '../../interfaces'
 import { executeAction, socketMessage } from '../../actions'
 import { componentActions } from '../'
-import {
-  BladeMethod,
-  SwWebRTCCallState,
-  VertoMethod,
-} from '../../../utils/constants'
+import { BladeMethod, VertoMethod } from '../../../utils/constants'
 import { BladeExecute } from '../../../RPCMessages'
 import { logger } from '../../../utils'
 
@@ -90,7 +86,7 @@ export function* sessionChannelWatcher({
       case VertoMethod.Media: {
         const component = {
           id: params.callID,
-          state: SwWebRTCCallState.Early,
+          state: 'early',
           remoteSDP: params.sdp,
           nodeId,
         }
@@ -109,7 +105,7 @@ export function* sessionChannelWatcher({
       case VertoMethod.Answer: {
         const component: WebRTCCall = {
           id: params.callID,
-          state: SwWebRTCCallState.Active,
+          state: 'active',
           nodeId,
         }
         if (params?.sdp) {
@@ -130,7 +126,7 @@ export function* sessionChannelWatcher({
       case VertoMethod.Bye: {
         const component: WebRTCCall = {
           id: params.callID,
-          state: SwWebRTCCallState.Hangup,
+          state: 'hangup',
           nodeId,
           byeCause: params?.cause ?? '',
           byeCauseCode: params?.causeCode ?? 0,

--- a/packages/core/src/redux/interfaces.ts
+++ b/packages/core/src/redux/interfaces.ts
@@ -6,6 +6,7 @@ import {
   SessionAuthStatus,
   SessionStatus,
   BladeExecuteMethod,
+  CallState,
 } from '../utils/interfaces'
 
 interface SWComponent {
@@ -18,7 +19,7 @@ interface SWComponent {
 }
 
 export interface WebRTCCall extends SWComponent {
-  state?: string
+  state?: CallState
   remoteSDP?: string
   nodeId?: string
   roomId?: string

--- a/packages/core/src/utils/constants.ts
+++ b/packages/core/src/utils/constants.ts
@@ -44,22 +44,6 @@ export enum VertoMethod {
   Announce = 'verto.announce',
 }
 
-// TODO: do we still need these of if we can just `CallState` instead.
-export enum SwWebRTCCallState {
-  New = 'new',
-  Requesting = 'requesting',
-  Trying = 'trying',
-  Recovering = 'recovering',
-  Ringing = 'ringing',
-  Answering = 'answering',
-  Early = 'early',
-  Active = 'active',
-  Held = 'held',
-  Hangup = 'hangup',
-  Destroy = 'destroy',
-  Purge = 'purge',
-}
-
 // export enum SwEvent {
 //   // Socket Events
 //   SocketOpen = 'signalwire.socket.open',


### PR DESCRIPTION
As discussed today, this PR removes the `SwWebRTCCallState` enum in favour of the CallState type.