### PR TITLE
Fix createRoomObject camera/microphone checks

### DIFF
--- a/.changeset/sweet-needles-pretend.md
+++ b/.changeset/sweet-needles-pretend.md
@@ -2,4 +2,4 @@
 '@signalwire/js': patch
 ---
 
-fix stopMicrophoneWhileMuted and stopCameraWhileMuted check
+Always check stopMicrophoneWhileMuted and stopCameraWhileMuted in createRoomObject

--- a/.changeset/sweet-needles-pretend.md
+++ b/.changeset/sweet-needles-pretend.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': patch
+---
+
+fix stopMicrophoneWhileMuted and stopCameraWhileMuted check


### PR DESCRIPTION
Just moved `stopMicrophoneWhileMuted` and `stopCameraWhileMuted` logic outside of rootElementId condition to always stop/restore media. 