### PR TITLE
Normalize build across packages

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,7 @@
   "homepage": "https://github.com/signalwire/signalwire-js/tree/master/packages/core",
   "scripts": {
     "start": "microbundle watch -f modern,es --define process.env.NODE_ENV=development --tsconfig tsconfig.build.json",
-    "build": "pkg-typings --pre-run && microbundle --external none -f modern,es,cjs --define process.env.NODE_ENV=production --tsconfig ./tsconfig.build.json --target node && pkg-typings --after-run",
+    "build": "pkg-typings --pre-run && microbundle -f modern,es,cjs --define process.env.NODE_ENV=production --tsconfig ./tsconfig.build.json --target node && pkg-typings --after-run",
     "test": "NODE_ENV=test jest",
     "prepare": "npm run build"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,8 +38,8 @@
   },
   "homepage": "https://github.com/signalwire/signalwire-js/tree/master/packages/core",
   "scripts": {
-    "start": "microbundle watch -f modern,es --define process.env.NODE_ENV=development --tsconfig tsconfig.build.json",
-    "build": "pkg-typings --pre-run && microbundle -f modern,es,cjs --define process.env.NODE_ENV=production --tsconfig ./tsconfig.build.json --target node && pkg-typings --after-run",
+    "start": "microbundle watch -f modern,esm --define process.env.NODE_ENV=development --tsconfig tsconfig.build.json",
+    "build": "pkg-typings --pre-run && microbundle -f modern,esm,cjs --define process.env.NODE_ENV=production --tsconfig ./tsconfig.build.json --target node && pkg-typings --after-run",
     "test": "NODE_ENV=test jest",
     "prepare": "npm run build"
   },

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -35,7 +35,8 @@
   "homepage": "https://github.com/signalwire/signalwire-js/tree/master/packages/js",
   "scripts": {
     "start": "microbundle watch -f modern,es --define process.env.NODE_ENV=development --tsconfig tsconfig.build.json",
-    "build": "pkg-typings --pre-run && microbundle --external none --define process.env.NODE_ENV=production --name SignalWire --tsconfig ./tsconfig.build.json && pkg-typings --after-run",
+    "build": "pkg-typings --pre-run && microbundle -f modern,esm,cjs --define process.env.NODE_ENV=production --name SignalWire --tsconfig ./tsconfig.build.json && npm run build:umd && pkg-typings --after-run",
+    "build:umd": "microbundle -f umd --external none --define process.env.NODE_ENV=production --name SignalWire --tsconfig ./tsconfig.build.json",
     "test": "NODE_ENV=test jest",
     "example": "(cd examples && npm run dev)",
     "docs": "typedoc --options typedoc.js",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -38,8 +38,8 @@
   },
   "homepage": "https://github.com/signalwire/signalwire-node/tree/master/packages/node",
   "scripts": {
-    "start": "microbundle watch -f es,modern --define process.env.NODE_ENV=development --tsconfig ./tsconfig.build.json --target node",
-    "build": "pkg-typings --pre-run && microbundle --external none -f modern,es,cjs --define process.env.NODE_ENV=production --tsconfig ./tsconfig.build.json --target node && pkg-typings --after-run",
+    "start": "microbundle watch -f esm,modern --define process.env.NODE_ENV=development --tsconfig ./tsconfig.build.json --target node",
+    "build": "pkg-typings --pre-run && microbundle --external none -f modern,esm,cjs --define process.env.NODE_ENV=production --tsconfig ./tsconfig.build.json --target node && pkg-typings --after-run",
     "test": "NODE_ENV=test jest",
     "prepare": "npm run build",
     "docs": "typedoc --options typedoc.js",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -39,7 +39,7 @@
   "homepage": "https://github.com/signalwire/signalwire-node/tree/master/packages/node",
   "scripts": {
     "start": "microbundle watch -f esm,modern --define process.env.NODE_ENV=development --tsconfig ./tsconfig.build.json --target node",
-    "build": "pkg-typings --pre-run && microbundle --external none -f modern,esm,cjs --define process.env.NODE_ENV=production --tsconfig ./tsconfig.build.json --target node && pkg-typings --after-run",
+    "build": "pkg-typings --pre-run && microbundle -f modern,esm,cjs --define process.env.NODE_ENV=production --tsconfig ./tsconfig.build.json --target node && pkg-typings --after-run",
     "test": "NODE_ENV=test jest",
     "prepare": "npm run build",
     "docs": "typedoc --options typedoc.js",

--- a/packages/webrtc/package.json
+++ b/packages/webrtc/package.json
@@ -33,8 +33,8 @@
   },
   "homepage": "https://github.com/signalwire/signalwire-js/tree/master/packages/webrtc",
   "scripts": {
-    "start": "microbundle watch -f modern,es --define process.env.NODE_ENV=development --tsconfig tsconfig.build.json",
-    "build": "pkg-typings --pre-run && microbundle -f modern,es,cjs --define process.env.NODE_ENV=production --tsconfig ./tsconfig.build.json --target node && pkg-typings --after-run",
+    "start": "microbundle watch -f modern,esm --define process.env.NODE_ENV=development --tsconfig tsconfig.build.json",
+    "build": "pkg-typings --pre-run && microbundle -f modern,esm,cjs --define process.env.NODE_ENV=production --tsconfig ./tsconfig.build.json --target node && pkg-typings --after-run",
     "test": "NODE_ENV=test jest",
     "prepare": "npm run build build",
     "docs": "typedoc --options typedoc.js",

--- a/packages/webrtc/package.json
+++ b/packages/webrtc/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/signalwire/signalwire-js/tree/master/packages/webrtc",
   "scripts": {
     "start": "microbundle watch -f modern,es --define process.env.NODE_ENV=development --tsconfig tsconfig.build.json",
-    "build": "pkg-typings --pre-run && microbundle --external none -f modern,es,cjs --define process.env.NODE_ENV=production --tsconfig ./tsconfig.build.json --target node && pkg-typings --after-run",
+    "build": "pkg-typings --pre-run && microbundle -f modern,es,cjs --define process.env.NODE_ENV=production --tsconfig ./tsconfig.build.json --target node && pkg-typings --after-run",
     "test": "NODE_ENV=test jest",
     "prepare": "npm run build build",
     "docs": "typedoc --options typedoc.js",


### PR DESCRIPTION
The code in this changeset includes a fix for our bundling scripts. Previously we were bundling all of the libraries (and their dependencies) into each bundle which ended up causing issues when we needed to re-use something like `uuid` (which has different runtime deps depending on the environment) from `js` and `node`. From now on dependencies will me installed (instead of bundled) so each environment will have the option to pick what's best.