### PR TITLE
Review Reconnect

### DIFF
--- a/.changeset/honest-pets-destroy.md
+++ b/.changeset/honest-pets-destroy.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': patch
+---
+
+Fix session reconnect logic

--- a/packages/core/src/BaseSession.test.ts
+++ b/packages/core/src/BaseSession.test.ts
@@ -75,10 +75,10 @@ describe('BaseSession', () => {
     }
     ws.send(JSON.stringify(request))
 
-    expect(session['_idle']).toBe(false)
+    expect(session.status).toEqual('unknown')
     const response = BladeDisconnectResponse(request.id)
     await expect(ws).toReceiveMessage(JSON.stringify(response))
-    expect(session['_idle']).toBe(true)
+    expect(session.status).toEqual('idle')
   })
 
   it('should invoke dispatch with socketMessage action for any other message', async () => {

--- a/packages/core/src/BaseSession.ts
+++ b/packages/core/src/BaseSession.ts
@@ -62,7 +62,7 @@ export class BaseSession {
     this.execute = this.execute.bind(this)
     this.connect = this.connect.bind(this)
 
-    this.logger.setLevel(this.logger.levels.INFO)
+    this.logger.setLevel(this.logger.levels.DEBUG)
   }
 
   get bladeConnectResult() {
@@ -208,6 +208,11 @@ export class BaseSession {
       this._emptyRequestQueue()
 
       this.dispatch(authSuccess())
+
+      // Testing drop connection
+      setTimeout(() => {
+        this._closeConnection()
+      }, 5000)
     } catch (error) {
       logger.error('Auth Error', error)
       this.dispatch(authError({ error }))
@@ -302,7 +307,9 @@ export class BaseSession {
 
   private _closeConnection() {
     if (this._socket) {
-      this._socket.close()
+      // @ts-ignore
+      this._socket.terminate()
+      // this._socket.close()
       this._socket = null
     }
   }

--- a/packages/core/src/BaseSession.ts
+++ b/packages/core/src/BaseSession.ts
@@ -230,7 +230,9 @@ export class BaseSession {
 
   protected _onSocketClose(event: CloseEvent) {
     logger.debug('_onSocketClose', event.type, event.code, event.reason)
-    this.dispatch(socketClosed({ code: event.code, reason: event.reason }))
+    this._status =
+      event.code >= 1006 && event.code <= 1014 ? 'reconnecting' : 'disconnected'
+    this.dispatch(socketClosed())
     this._socket = null
   }
 

--- a/packages/core/src/BaseSession.ts
+++ b/packages/core/src/BaseSession.ts
@@ -63,7 +63,7 @@ export class BaseSession {
     this.execute = this.execute.bind(this)
     this.connect = this.connect.bind(this)
 
-    this.logger.setLevel(this.logger.levels.DEBUG)
+    this.logger.setLevel(this.logger.levels.INFO)
   }
 
   get bladeConnectResult() {

--- a/packages/core/src/BaseSession.ts
+++ b/packages/core/src/BaseSession.ts
@@ -309,7 +309,9 @@ export class BaseSession {
     )
   }
 
-  private _closeConnection(status: SessionStatus) {
+  private _closeConnection(
+    status: Extract<SessionStatus, 'reconnecting' | 'disconnected'>
+  ) {
     this._status = status
     if (this._socket) {
       this._socket.close()

--- a/packages/core/src/BaseSession.ts
+++ b/packages/core/src/BaseSession.ts
@@ -149,14 +149,8 @@ export class BaseSession {
    * @return Promise that will resolve/reject depending on the server response
    */
   execute(msg: JSONRPCRequest | JSONRPCResponse): Promise<any> {
-    if (this._idle) {
+    if (this._idle || !this.connected) {
       return new Promise((resolve) => this._requestQueue.push({ resolve, msg }))
-    }
-    if (!this.connected) {
-      return new Promise((resolve) => {
-        this._requestQueue.push({ resolve, msg })
-        this.connect()
-      })
     }
     let promise: Promise<unknown>
     if ('params' in msg) {

--- a/packages/core/src/BaseSession.ts
+++ b/packages/core/src/BaseSession.ts
@@ -62,7 +62,7 @@ export class BaseSession {
     this.execute = this.execute.bind(this)
     this.connect = this.connect.bind(this)
 
-    this.logger.setLevel(this.logger.levels.DEBUG)
+    this.logger.setLevel(this.logger.levels.INFO)
   }
 
   get bladeConnectResult() {
@@ -307,9 +307,7 @@ export class BaseSession {
 
   private _closeConnection() {
     if (this._socket) {
-      // @ts-ignore
-      this._socket.terminate()
-      // this._socket.close()
+      this._socket.close()
       this._socket = null
     }
   }

--- a/packages/core/src/BaseSession.ts
+++ b/packages/core/src/BaseSession.ts
@@ -212,11 +212,6 @@ export class BaseSession {
       this._emptyRequestQueue()
       this._status = 'connected'
       this.dispatch(authSuccess())
-
-      // Testing drop connection
-      setTimeout(() => {
-        this._closeConnection('reconnecting')
-      }, 5000)
     } catch (error) {
       logger.error('Auth Error', error)
       this.dispatch(authError({ error }))

--- a/packages/core/src/redux/actions.ts
+++ b/packages/core/src/redux/actions.ts
@@ -4,7 +4,7 @@ import {
   SessionAuthError,
   SessionEvents,
 } from '../utils/interfaces'
-import { ExecuteActionParams, SocketCloseParams } from './interfaces'
+import { ExecuteActionParams } from './interfaces'
 
 export const initAction = createAction('swSdk/init')
 export const destroyAction = createAction('swSdk/destroy')
@@ -19,7 +19,7 @@ export const executeAction = createAction<ExecuteActionParams>(
 export const authError = createAction<{ error: SessionAuthError }>('auth/error')
 export const authSuccess = createAction('auth/success')
 
-export const socketClosed = createAction<SocketCloseParams>('socket/closed')
+export const socketClosed = createAction('socket/closed')
 export const socketError = createAction('socket/error')
 export const socketMessage = createAction<JSONRPCRequest, string>(
   'socket/message'

--- a/packages/core/src/redux/features/session/sessionSlice.test.ts
+++ b/packages/core/src/redux/features/session/sessionSlice.test.ts
@@ -18,7 +18,6 @@ describe('SessionState Tests', () => {
       iceServers: bladeConnectResultVRT.result?.iceServers,
       authStatus: 'authorized',
       authError: undefined,
-      status: 'connected',
     })
   })
 

--- a/packages/core/src/redux/features/session/sessionSlice.ts
+++ b/packages/core/src/redux/features/session/sessionSlice.ts
@@ -3,7 +3,6 @@ import { SessionState } from '../../interfaces'
 import {
   IBladeConnectResult,
   SessionAuthError,
-  SessionStatus,
 } from '../../../utils/interfaces'
 import { destroyAction, authError } from '../../actions'
 
@@ -12,7 +11,6 @@ export const initialSessionState: Readonly<SessionState> = {
   iceServers: [],
   authStatus: 'unknown',
   authError: undefined,
-  status: 'unknown',
 }
 
 const sessionSlice = createSlice({
@@ -21,12 +19,8 @@ const sessionSlice = createSlice({
   reducers: {
     connected: (state, { payload }: PayloadAction<IBladeConnectResult>) => {
       state.authStatus = 'authorized'
-      state.status = 'connected'
       state.protocol = payload?.result?.protocol ?? ''
       state.iceServers = payload?.result?.iceServers ?? []
-    },
-    statusChange: (state, { payload }: PayloadAction<SessionStatus>) => {
-      state.status = payload
     },
   },
   extraReducers: (builder) => {

--- a/packages/core/src/redux/interfaces.ts
+++ b/packages/core/src/redux/interfaces.ts
@@ -46,7 +46,6 @@ export interface SessionState {
   iceServers?: RTCIceServer[]
   authStatus: SessionAuthStatus
   authError?: SessionAuthError
-  status: SessionStatus
 }
 
 export interface SDKState {

--- a/packages/core/src/redux/interfaces.ts
+++ b/packages/core/src/redux/interfaces.ts
@@ -59,8 +59,3 @@ export interface ExecuteActionParams {
   method: BladeExecuteMethod
   params: Record<string, any>
 }
-
-export interface SocketCloseParams {
-  code: number
-  reason: string
-}

--- a/packages/core/src/redux/rootSaga.test.ts
+++ b/packages/core/src/redux/rootSaga.test.ts
@@ -85,7 +85,7 @@ describe('socketClosedWorker', () => {
   })
 })
 
-describe.only('sessionStatusWatcher', () => {
+describe('sessionStatusWatcher', () => {
   const actions = [
     authSuccess.type,
     authError.type,

--- a/packages/core/src/redux/rootSaga.test.ts
+++ b/packages/core/src/redux/rootSaga.test.ts
@@ -198,7 +198,6 @@ describe('startSaga', () => {
   it('should put actions and fork watchers', () => {
     const pubSubTask = { cancel: jest.fn() }
     const executeActionTask = { cancel: jest.fn() }
-    // const sessionStatusTask = { cancel: jest.fn() }
 
     const saga = testSaga(startSaga, options)
     saga.next().put(sessionActions.connected(session.bladeConnectResult))
@@ -210,16 +209,11 @@ describe('startSaga', () => {
     })
 
     saga.next(pubSubTask).fork(executeActionWatcher, session)
-
-    // saga.next(executeActionTask).fork(sessionStatusWatcher, options)
-
-    // saga.next(sessionStatusTask).take(destroyAction.type)
     saga.next(executeActionTask).take(destroyAction.type)
     saga.next().isDone()
 
     expect(pubSubTask.cancel).toHaveBeenCalledTimes(1)
     expect(executeActionTask.cancel).toHaveBeenCalledTimes(1)
-    // expect(sessionStatusTask.cancel).toHaveBeenCalledTimes(1)
     expect(pubSubChannel.close).toHaveBeenCalledTimes(1)
     expect(sessionChannel.close).toHaveBeenCalledTimes(1)
   })

--- a/packages/core/src/redux/rootSaga.test.ts
+++ b/packages/core/src/redux/rootSaga.test.ts
@@ -40,7 +40,6 @@ describe('socketClosedWorker', () => {
       sessionChannel,
       payload: { code: 1006, reason: '' },
     })
-      .put(sessionActions.statusChange('reconnecting'))
       .call(session.connect)
       .run(timeout)
   })
@@ -60,7 +59,6 @@ describe('socketClosedWorker', () => {
         sessionChannel,
         payload: { code: 1002, reason: '' },
       })
-        .put(sessionActions.statusChange('disconnected'))
         .put(pubSubChannel, sessionDisconnected())
         .run(),
       expectSaga(socketClosedWorker, {
@@ -69,7 +67,6 @@ describe('socketClosedWorker', () => {
         sessionChannel,
         payload: { code: 1000, reason: '' },
       })
-        .put(sessionActions.statusChange('disconnected'))
         .put(pubSubChannel, sessionDisconnected())
         .run(),
       expectSaga(socketClosedWorker, {
@@ -78,7 +75,6 @@ describe('socketClosedWorker', () => {
         sessionChannel,
         payload: { code: 1020, reason: '' },
       })
-        .put(sessionActions.statusChange('disconnected'))
         .put(pubSubChannel, sessionDisconnected())
         .run(),
     ])

--- a/packages/core/src/redux/rootSaga.ts
+++ b/packages/core/src/redux/rootSaga.ts
@@ -50,6 +50,7 @@ export function* initSessionSaga(
     pubSubChannel,
   })
 
+  console.log('>>> initSessionSaga connect <<<')
   session.connect()
 
   const action = yield take([authSuccess.type, authError.type])
@@ -84,6 +85,7 @@ export function* socketClosedWorker({
     yield put(sessionActions.statusChange('reconnecting'))
     yield put(pubSubChannel, sessionReconnecting())
     yield delay(Math.random() * 2000)
+    console.log('>>> socketClosedWorker reconnecting? <<<')
     yield call(session.connect)
   } else {
     sessionChannel.close()
@@ -99,6 +101,8 @@ export function* sessionStatusWatcher(options: StartSagaOptions): SagaIterator {
     socketError.type,
     socketClosed.type,
   ])
+
+  console.log('>>> sessionStatusWatcher <<<', action.type)
 
   switch (action.type) {
     case authSuccess.type:

--- a/packages/core/src/redux/rootSaga.ts
+++ b/packages/core/src/redux/rootSaga.ts
@@ -75,7 +75,6 @@ export function* socketClosedWorker({
   if (session.status === 'reconnecting') {
     yield put(pubSubChannel, sessionReconnecting())
     yield delay(Math.random() * 2000)
-    console.log('>>> socketClosedWorker reconnecting? <<<')
     yield call(session.connect)
   } else {
     sessionChannel.close()

--- a/packages/core/src/redux/rootSaga.ts
+++ b/packages/core/src/redux/rootSaga.ts
@@ -1,7 +1,6 @@
 import { Task, SagaIterator, Channel } from '@redux-saga/types'
 import { channel, EventChannel } from 'redux-saga'
 import { fork, call, take, put, delay } from 'redux-saga/effects'
-import { SocketCloseParams } from './interfaces'
 import { UserOptions, SessionConstructor } from '../utils/interfaces'
 import {
   executeActionWatcher,
@@ -72,7 +71,6 @@ export function* socketClosedWorker({
   session: BaseSession
   sessionChannel: EventChannel<unknown>
   pubSubChannel: Channel<unknown>
-  payload: SocketCloseParams // TODO: remove it
 }) {
   if (session.status === 'reconnecting') {
     yield put(pubSubChannel, sessionReconnecting())
@@ -86,7 +84,6 @@ export function* socketClosedWorker({
 }
 
 export function* sessionStatusWatcher(options: StartSagaOptions): SagaIterator {
-  const { session, sessionChannel, pubSubChannel } = options
   while (true) {
     const action = yield take([
       authSuccess.type,
@@ -114,12 +111,7 @@ export function* sessionStatusWatcher(options: StartSagaOptions): SagaIterator {
         // })
         break
       case socketClosed.type:
-        yield fork(socketClosedWorker, {
-          session,
-          sessionChannel,
-          pubSubChannel,
-          payload: action.payload,
-        })
+        yield fork(socketClosedWorker, options)
     }
   }
 }

--- a/packages/core/src/redux/rootSaga.ts
+++ b/packages/core/src/redux/rootSaga.ts
@@ -102,7 +102,7 @@ export function* sessionStatusWatcher(options: StartSagaOptions): SagaIterator {
       case authError.type: {
         const { error: authError } = action.payload
         const error = authError
-          ? new AuthError(authError.code, authError.message)
+          ? new AuthError(authError.code, authError.error)
           : new Error('Unauthorized')
         throw error
       }

--- a/packages/core/src/redux/rootSaga.ts
+++ b/packages/core/src/redux/rootSaga.ts
@@ -19,6 +19,7 @@ import {
 import { sessionActions } from './features'
 import { BaseSession } from '..'
 import { authError, authSuccess, socketClosed, socketError } from './actions'
+import { AuthError } from '../CustomErrors'
 
 type StartSagaOptions = {
   session: BaseSession
@@ -98,8 +99,13 @@ export function* sessionStatusWatcher(options: StartSagaOptions): SagaIterator {
       case authSuccess.type:
         yield fork(startSaga, options)
         break
-      case authError.type:
-        throw new Error('Auth Error')
+      case authError.type: {
+        const { error: authError } = action.payload
+        const error = authError
+          ? new AuthError(authError.code, authError.message)
+          : new Error('Unauthorized')
+        throw error
+      }
       case socketError.type:
         // TODO: define if we want to emit external events here.
         // yield put(pubSubChannel, {

--- a/packages/core/src/redux/rootSaga.ts
+++ b/packages/core/src/redux/rootSaga.ts
@@ -67,25 +67,19 @@ export function* socketClosedWorker({
   session,
   sessionChannel,
   pubSubChannel,
-  payload: { code },
 }: {
   session: BaseSession
   sessionChannel: EventChannel<unknown>
   pubSubChannel: Channel<unknown>
-  payload: SocketCloseParams
+  payload: SocketCloseParams // TODO: remove it
 }) {
-  /**
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent
-   */
-  if (code >= 1006 && code <= 1014) {
-    yield put(sessionActions.statusChange('reconnecting'))
+  if (session.status === 'reconnecting') {
     yield put(pubSubChannel, sessionReconnecting())
     yield delay(Math.random() * 2000)
     console.log('>>> socketClosedWorker reconnecting? <<<')
     yield call(session.connect)
   } else {
     sessionChannel.close()
-    yield put(sessionActions.statusChange('disconnected'))
     yield put(pubSubChannel, sessionDisconnected())
   }
 }

--- a/packages/node/examples/ts-vanilla-websockets/index.ts
+++ b/packages/node/examples/ts-vanilla-websockets/index.ts
@@ -6,10 +6,10 @@ createWebSocketClient({
   token: '<project-token>',
 })
   .then((c) => {
-    c.connect()
     c.on('session.connected', () => {
       console.log('Connected!')
     })
+    c.connect().catch((e) => console.log('<Connect Error>', e))
   })
   .catch((e) => {
     console.log('<Error>', e)

--- a/packages/node/examples/vanilla-websockets/index.js
+++ b/packages/node/examples/vanilla-websockets/index.js
@@ -6,10 +6,10 @@ const client = createWebSocketClient({
   token: '<project-token>',
 })
   .then((c) => {
-    c.connect()
     c.on('session.connected', () => {
       console.log('Connected!')
     })
+    c.connect().catch((e) => console.log('<Connect Error>', e))
   })
   .catch((e) => {
     console.log('<Error>', e)


### PR DESCRIPTION
@framini i was testing the reconnect login and it seems that `sessionStatusWatcher` and `socketClosedWorker` are not invoked after the first reconnection. 
I think we're missing to start again the `sessionStatusWatcher`? 

Can you take a look please?