### PR TITLE
WIP: Review reconnect test

### DIFF
--- a/packages/core/src/BaseSession.ts
+++ b/packages/core/src/BaseSession.ts
@@ -211,6 +211,8 @@ export class BaseSession {
 
       // Testing drop connection
       setTimeout(() => {
+        console.log('----> Calling this._closeConnection()')
+
         this._closeConnection()
       }, 5000)
     } catch (error) {
@@ -308,8 +310,8 @@ export class BaseSession {
   private _closeConnection() {
     if (this._socket) {
       // @ts-ignore
-      this._socket.terminate()
-      // this._socket.close()
+      // this._socket.terminate()
+      this._socket.close()
       this._socket = null
     }
   }


### PR DESCRIPTION
### Changes
1. making sessionStatusWatcher restartable: without this we break the action dispatch link. Meaning, when the connection is closed and we dispatch socket/closed nobody is listening without this (on the second and above try)
2. Disabled listening for authSuccess inside sessionStatusWatcher  since otherwise we enter into a loop between startSaga and sessionStatusWatcher  -> so we have to double check how to handle that case (authSuccess without using startSaga )

### To test:
1. `cd packages/core`
2. `npm start`
3. `cd packages/js`
4. `npm start`
5. `cd packages/js/examples`
6. `npm run dev`