### PR TITLE
Node Consumer API

### DIFF
--- a/.changeset/curly-icons-sip.md
+++ b/.changeset/curly-icons-sip.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': patch
+---
+
+Updated connect to support component and session listeners

--- a/.changeset/loud-chefs-poke.md
+++ b/.changeset/loud-chefs-poke.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/node': patch
+---
+
+Add Consumer API

--- a/packages/core/src/BaseClient.ts
+++ b/packages/core/src/BaseClient.ts
@@ -1,33 +1,11 @@
-import { Store } from 'redux'
 import { AuthError } from './CustomErrors'
 import { destroyAction, initAction } from './redux'
-import { BaseClientOptions, Emitter } from './utils/interfaces'
+import { BaseClientOptions } from './utils/interfaces'
+import { BaseComponent } from './BaseComponent'
 
-export class BaseClient implements Emitter {
-  constructor(public options: BaseClientOptions, public store: Store) {}
-
-  get emitter() {
-    return this.options.emitter
-  }
-
-  on(...params: Parameters<Emitter['on']>) {
-    return this.emitter.on(...params)
-  }
-
-  off(...params: Parameters<Emitter['off']>) {
-    return this.emitter.off(...params)
-  }
-
-  once(...params: Parameters<Emitter['once']>) {
-    return this.emitter.once(...params)
-  }
-
-  emit(...params: Parameters<Emitter['emit']>) {
-    return this.emitter.emit(...params)
-  }
-
-  removeAllListeners(...params: Parameters<Emitter['removeAllListeners']>) {
-    return this.emitter.removeAllListeners(...params)
+export class BaseClient extends BaseComponent {
+  constructor(public options: BaseClientOptions) {
+    super(options)
   }
 
   /**

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -1,13 +1,11 @@
 import { uuid } from './utils'
 import { executeAction } from './redux'
-import { BladeExecuteMethod, Emitter } from './utils/interfaces'
+import {
+  ExecuteParams,
+  BaseComponentOptions,
+  Emitter,
+} from './utils/interfaces'
 import { SDKState } from './redux/interfaces'
-import { BaseComponentOptions } from './utils/interfaces'
-
-type ExecuteParams = {
-  method: BladeExecuteMethod
-  params: Record<string, any>
-}
 
 export class BaseComponent implements Emitter {
   id = uuid()

--- a/packages/core/src/BaseSession.ts
+++ b/packages/core/src/BaseSession.ts
@@ -63,7 +63,7 @@ export class BaseSession {
     this.execute = this.execute.bind(this)
     this.connect = this.connect.bind(this)
 
-    this.logger.setLevel(this.logger.levels.INFO)
+    this.logger.setLevel(this.logger.levels.DEBUG)
   }
 
   get bladeConnectResult() {

--- a/packages/core/src/BaseSession.ts
+++ b/packages/core/src/BaseSession.ts
@@ -63,7 +63,7 @@ export class BaseSession {
     this.execute = this.execute.bind(this)
     this.connect = this.connect.bind(this)
 
-    this.logger.setLevel(this.logger.levels.DEBUG)
+    this.logger.setLevel(this.logger.levels.INFO)
   }
 
   get bladeConnectResult() {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ import { BaseClient } from './BaseClient'
 import { BaseComponent } from './BaseComponent'
 import { EventEmitter, getEventEmitter } from './utils/EventEmitter'
 import * as sessionSelectors from './redux/features/session/sessionSelectors'
+import { executeAction } from './redux'
 
 // prettier-ignore
 export {
@@ -18,6 +19,7 @@ export {
   connect,
   configureStore,
   EventEmitter,
+  executeAction,
   getEventEmitter
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,7 +6,6 @@ import { BaseClient } from './BaseClient'
 import { BaseComponent } from './BaseComponent'
 import { EventEmitter, getEventEmitter } from './utils/EventEmitter'
 import * as sessionSelectors from './redux/features/session/sessionSelectors'
-import { executeAction } from './redux'
 
 // prettier-ignore
 export {
@@ -19,7 +18,6 @@ export {
   connect,
   configureStore,
   EventEmitter,
-  executeAction,
   getEventEmitter
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,7 @@ export * from './RPCMessages'
 export * from './utils/interfaces'
 export { VertoMethod } from './utils/constants'
 export * from './CustomErrors'
+export type { SessionState } from './redux/interfaces'
 
 export const selectors = {
   ...sessionSelectors,

--- a/packages/core/src/redux/connect.test.ts
+++ b/packages/core/src/redux/connect.test.ts
@@ -16,7 +16,7 @@ describe('Connect', () => {
     store = configureJestStore()
     instance = connect({
       store,
-      onStateChangeListeners: {
+      componentListeners: {
         state: 'emit',
         remoteSDP: mockOnRemoteSDP,
       },

--- a/packages/core/src/redux/connect.ts
+++ b/packages/core/src/redux/connect.ts
@@ -57,6 +57,7 @@ export const connect = <T extends { id: string; destroyer: () => void }>(
         }
       })
 
+      // TODO: refactor this to avoid repetition with the above.
       const session = getSession(store.getState())
       sessionKeys.forEach((reduxKey) => {
         const cacheKey = `session.${reduxKey}`

--- a/packages/core/src/redux/features/session/sessionSelectors.ts
+++ b/packages/core/src/redux/features/session/sessionSelectors.ts
@@ -3,3 +3,7 @@ import { SDKState } from '../../interfaces'
 export const getIceServers = ({ session }: SDKState) => {
   return session?.iceServers ?? []
 }
+
+export const getSession = (store: SDKState) => {
+  return store.session
+}

--- a/packages/core/src/redux/features/session/sessionSelectors.ts
+++ b/packages/core/src/redux/features/session/sessionSelectors.ts
@@ -7,3 +7,7 @@ export const getIceServers = ({ session }: SDKState) => {
 export const getSession = (store: SDKState) => {
   return store.session
 }
+
+export const getAuthStatus = ({ session }: SDKState) => {
+  return session.authStatus
+}

--- a/packages/core/src/redux/interfaces.ts
+++ b/packages/core/src/redux/interfaces.ts
@@ -3,7 +3,6 @@ import {
   JSONRPCResponse,
   SessionAuthError,
   SessionAuthStatus,
-  SessionStatus,
   BladeExecuteMethod,
   CallState,
 } from '../utils/interfaces'

--- a/packages/core/src/redux/rootSaga.test.ts
+++ b/packages/core/src/redux/rootSaga.test.ts
@@ -180,16 +180,18 @@ describe('startSaga', () => {
     const executeActionTask = { cancel: jest.fn() }
 
     const saga = testSaga(startSaga, options)
-    saga.next().put(sessionActions.connected(session.bladeConnectResult))
-    saga.next().put(pubSubChannel, sessionConnected())
-
     saga.next().fork(pubSubSaga, {
       pubSubChannel,
       emitter: userOptions.emitter,
     })
-
     saga.next(pubSubTask).fork(executeActionWatcher, session)
-    saga.next(executeActionTask).take(destroyAction.type)
+
+    saga
+      .next(executeActionTask)
+      .put(sessionActions.connected(session.bladeConnectResult))
+    saga.next().put(pubSubChannel, sessionConnected())
+
+    saga.next().take(destroyAction.type)
     saga.next().isDone()
 
     expect(pubSubTask.cancel).toHaveBeenCalledTimes(1)

--- a/packages/core/src/redux/rootSaga.ts
+++ b/packages/core/src/redux/rootSaga.ts
@@ -117,6 +117,13 @@ export function* sessionStatusWatcher(options: StartSagaOptions): SagaIterator {
 
 export function* startSaga(options: StartSagaOptions): SagaIterator {
   const { session, sessionChannel, pubSubChannel, userOptions } = options
+
+  // TODO: review this
+  /**
+   * Fork the watcher for all the blade.execute requests
+   */
+  const executeActionTask: Task = yield fork(executeActionWatcher, session)
+
   yield put(sessionActions.connected(session.bladeConnectResult))
   yield put(pubSubChannel, sessionConnected())
 
@@ -124,11 +131,6 @@ export function* startSaga(options: StartSagaOptions): SagaIterator {
     pubSubChannel,
     emitter: userOptions.emitter,
   })
-
-  /**
-   * Fork the watcher for all the blade.execute requests
-   */
-  const executeActionTask: Task = yield fork(executeActionWatcher, session)
 
   /**
    * Wait for a destroyAction to teardown all the things

--- a/packages/core/src/redux/rootSaga.ts
+++ b/packages/core/src/redux/rootSaga.ts
@@ -118,15 +118,14 @@ export function* sessionStatusWatcher(options: StartSagaOptions): SagaIterator {
 export function* startSaga(options: StartSagaOptions): SagaIterator {
   const { session, sessionChannel, pubSubChannel, userOptions } = options
 
-  /**
-   * Fork the watcher for all the blade.execute requests
-   */
-  const executeActionTask: Task = yield fork(executeActionWatcher, session)
-
   const pubSubTask: Task = yield fork(pubSubSaga, {
     pubSubChannel,
     emitter: userOptions.emitter,
   })
+  /**
+   * Fork the watcher for all the blade.execute requests
+   */
+  const executeActionTask: Task = yield fork(executeActionWatcher, session)
 
   yield put(sessionActions.connected(session.bladeConnectResult))
   yield put(pubSubChannel, sessionConnected())

--- a/packages/core/src/redux/rootSaga.ts
+++ b/packages/core/src/redux/rootSaga.ts
@@ -118,19 +118,18 @@ export function* sessionStatusWatcher(options: StartSagaOptions): SagaIterator {
 export function* startSaga(options: StartSagaOptions): SagaIterator {
   const { session, sessionChannel, pubSubChannel, userOptions } = options
 
-  // TODO: review this
   /**
    * Fork the watcher for all the blade.execute requests
    */
   const executeActionTask: Task = yield fork(executeActionWatcher, session)
 
-  yield put(sessionActions.connected(session.bladeConnectResult))
-  yield put(pubSubChannel, sessionConnected())
-
   const pubSubTask: Task = yield fork(pubSubSaga, {
     pubSubChannel,
     emitter: userOptions.emitter,
   })
+
+  yield put(sessionActions.connected(session.bladeConnectResult))
+  yield put(pubSubChannel, sessionConnected())
 
   /**
    * Wait for a destroyAction to teardown all the things

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -48,7 +48,13 @@ export interface UserOptions extends SessionOptions {
   emitter?: Emitter
 }
 
+/**
+ * `UserOptions` is exposed to the end user and `BaseClientOptions` is
+ * the interface we use internally that extends the options provided.
+ * @internal
+ */
 export interface BaseClientOptions extends UserOptions {
+  store: Store
   emitter: Emitter
 }
 
@@ -378,4 +384,9 @@ export interface WebSocketClient {
 }
 export interface WebSocketAdapter {
   new (url: string, protocols?: string | string[]): WebSocketClient
+}
+
+export type ExecuteParams = {
+  method: BladeExecuteMethod
+  params: Record<string, any>
 }

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -375,6 +375,7 @@ export type RoomMethod =
 export type BladeExecuteMethod =
   | RoomMethod
   | 'video.message'
+  | 'signalwire.subscribe'
 
 export interface WebSocketClient {
   addEventListener: WebSocket['addEventListener']

--- a/packages/js/src/Client.ts
+++ b/packages/js/src/Client.ts
@@ -17,7 +17,7 @@ export class Client extends BaseClient {
         const call: RoomObject = connect({
           store: this.store,
           Component: Call,
-          onStateChangeListeners: {
+          componentListeners: {
             state: 'onStateChange',
             remoteSDP: 'onRemoteSDP',
             roomId: 'onRoomId',

--- a/packages/js/src/createClient.ts
+++ b/packages/js/src/createClient.ts
@@ -1,7 +1,7 @@
 import {
-  BaseClientOptions,
   ClientEvents,
   configureStore,
+  connect,
   getEventEmitter,
   UserOptions,
 } from '@signalwire/core'
@@ -51,10 +51,8 @@ import { JWTSession } from './JWTSession'
  * }
  * ```
  */
-export const createClient = async (
-  userOptions: UserOptions
-): Promise<Client> => {
-  const baseUserOptions: BaseClientOptions = {
+export const createClient = async (userOptions: UserOptions) => {
+  const baseUserOptions = {
     ...userOptions,
     emitter: getEventEmitter<ClientEvents>(userOptions),
   }
@@ -62,10 +60,14 @@ export const createClient = async (
     userOptions: baseUserOptions,
     SessionConstructor: JWTSession,
   })
-  const client: StrictEventEmitter<Client, ClientEvents> = new Client(
-    baseUserOptions,
-    store
-  )
+  const client: StrictEventEmitter<Client, ClientEvents> = connect({
+    store,
+    Component: Client,
+    onStateChangeListeners: {
+      errors: 'onError',
+      responses: 'onSuccess',
+    },
+  })(baseUserOptions)
   if (baseUserOptions.autoConnect) {
     await client.connect()
   }

--- a/packages/js/src/createClient.ts
+++ b/packages/js/src/createClient.ts
@@ -63,7 +63,7 @@ export const createClient = async (userOptions: UserOptions) => {
   const client: StrictEventEmitter<Client, ClientEvents> = connect({
     store,
     Component: Client,
-    onStateChangeListeners: {
+    componentListeners: {
       errors: 'onError',
       responses: 'onSuccess',
     },

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -1,8 +1,3 @@
 export * as Video from './video'
 export * as WebRTC from '@signalwire/webrtc'
-export type {
-  BaseClientOptions,
-  ClientEvents,
-  UserOptions,
-  Emitter,
-} from '@signalwire/core'
+export type { ClientEvents, UserOptions, Emitter } from '@signalwire/core'

--- a/packages/node/examples/ts-vanilla-websockets/index.ts
+++ b/packages/node/examples/ts-vanilla-websockets/index.ts
@@ -4,12 +4,20 @@ createWebSocketClient({
   host: 'relay.swire.io',
   project: '<project-id>',
   token: '<project-token>',
+  autoConnect: true,
 })
   .then((c) => {
-    c.on('session.connected', () => {
-      console.log('Connected!')
+    const consumer = c.video.createConsumer()
+
+    consumer.subscribe('room.started', () => {
+      console.log('🟢 ROOOM STARTED 🟢')
     })
-    c.connect().catch((e) => console.log('<Connect Error>', e))
+
+    consumer.subscribe('room.ended', () => {
+      console.log('🔴 ROOOM ENDED 🔴')
+    })
+
+    consumer.run()
   })
   .catch((e) => {
     console.log('<Error>', e)

--- a/packages/node/examples/ts-vanilla-websockets/index.ts
+++ b/packages/node/examples/ts-vanilla-websockets/index.ts
@@ -1,13 +1,15 @@
 import { createWebSocketClient } from '@signalwire/node'
 
-createWebSocketClient({
-  host: 'relay.swire.io',
-  project: '<project-id>',
-  token: '<project-token>',
-  autoConnect: true,
-})
-  .then((c) => {
-    const consumer = c.video.createConsumer()
+async function run() {
+  try {
+    const client = await createWebSocketClient({
+      host: 'relay.swire.io',
+      project: '<project-id>',
+      token: '<project-token>',
+      // autoConnect: true,
+    })
+
+    const consumer = client.video.createConsumer()
 
     consumer.subscribe('room.started', () => {
       console.log('🟢 ROOOM STARTED 🟢')
@@ -17,8 +19,19 @@ createWebSocketClient({
       console.log('🔴 ROOOM ENDED 🔴')
     })
 
-    consumer.run()
-  })
-  .catch((e) => {
-    console.log('<Error>', e)
-  })
+    consumer
+      .run()
+      .then(() => {
+        console.log('Consumer running!')
+      })
+      .catch((e) => {
+        console.log(`Consumer couldn't run`, e)
+      })
+
+    await client.connect()
+  } catch (error) {
+    console.log('<Error>', error)
+  }
+}
+
+run()

--- a/packages/node/src/Client.ts
+++ b/packages/node/src/Client.ts
@@ -1,8 +1,24 @@
-import { BaseClient, logger } from '@signalwire/core'
+import {
+  BaseClient,
+  ExecuteParams,
+  logger,
+  SessionState,
+  selectors,
+} from '@signalwire/core'
 
 // TODO: reuse types from @signalwire/core
 type GlobalVideoEvents = 'room.started' | 'room.ended'
 export class Client extends BaseClient {
+  private _executionQueue = new Set<ExecuteParams>()
+
+  onAuth(session: SessionState) {
+    if (session.authStatus === 'authorized') {
+      this._executionQueue.forEach((execParams) => {
+        this.execute(execParams)
+      })
+    }
+  }
+
   get video() {
     return {
       createConsumer: () => {
@@ -19,14 +35,26 @@ export class Client extends BaseClient {
           },
           run: () => {
             if (subscriptions.length > 0) {
-              this.execute({
+              const execParams: ExecuteParams = {
                 method: 'signalwire.subscribe',
                 params: {
                   event_channel: 'rooms',
                   get_initial_state: true,
                   events: subscriptions,
                 },
-              })
+              }
+
+              /**
+               * If the user is authorized we'll execute the action
+               * right away. Otherwise we'll put the execute in a
+               * queue and run it as soon as we detect the
+               * `session.authStatus === 'authorized'`
+               */
+              if (this.select(selectors.getAuthStatus) === 'authorized') {
+                this.execute(execParams)
+              } else {
+                this._executionQueue.add(execParams)
+              }
             } else {
               logger.warn(
                 '`consumer.run()` was called without any listeners attached.'

--- a/packages/node/src/Client.ts
+++ b/packages/node/src/Client.ts
@@ -20,7 +20,6 @@ export class Client extends BaseClient {
           run: () => {
             if (subscriptions.length > 0) {
               this.execute({
-                // @ts-ignore
                 method: 'signalwire.subscribe',
                 params: {
                   event_channel: 'rooms',

--- a/packages/node/src/Client.ts
+++ b/packages/node/src/Client.ts
@@ -1,4 +1,4 @@
-import { BaseClient } from '@signalwire/core'
+import { BaseClient, logger } from '@signalwire/core'
 import { executeAction } from '@signalwire/core'
 
 // TODO: reuse types from @signalwire/core
@@ -19,17 +19,23 @@ export class Client extends BaseClient {
             setSubscription(event)
           },
           run: () => {
-            this.store.dispatch(
-              executeAction({
-                // @ts-ignore
-                method: 'signalwire.subscribe',
-                params: {
-                  event_channel: 'rooms',
-                  get_initial_state: true,
-                  events: subscriptions,
-                },
-              })
-            )
+            if (subscriptions.length > 0) {
+              this.store.dispatch(
+                executeAction({
+                  // @ts-ignore
+                  method: 'signalwire.subscribe',
+                  params: {
+                    event_channel: 'rooms',
+                    get_initial_state: true,
+                    events: ['room.started', 'room.ended'],
+                  },
+                })
+              )
+            } else {
+              logger.warn(
+                '`consumer.run()` was called without any listeners attached.'
+              )
+            }
           },
         }
       },

--- a/packages/node/src/Client.ts
+++ b/packages/node/src/Client.ts
@@ -25,7 +25,7 @@ export class Client extends BaseClient {
                 params: {
                   event_channel: 'rooms',
                   get_initial_state: true,
-                  events: ['room.started', 'room.ended'],
+                  events: subscriptions,
                 },
               })
             } else {

--- a/packages/node/src/Client.ts
+++ b/packages/node/src/Client.ts
@@ -1,5 +1,4 @@
 import { BaseClient, logger } from '@signalwire/core'
-import { executeAction } from '@signalwire/core'
 
 // TODO: reuse types from @signalwire/core
 type GlobalVideoEvents = 'room.started' | 'room.ended'
@@ -20,17 +19,15 @@ export class Client extends BaseClient {
           },
           run: () => {
             if (subscriptions.length > 0) {
-              this.store.dispatch(
-                executeAction({
-                  // @ts-ignore
-                  method: 'signalwire.subscribe',
-                  params: {
-                    event_channel: 'rooms',
-                    get_initial_state: true,
-                    events: ['room.started', 'room.ended'],
-                  },
-                })
-              )
+              this.execute({
+                // @ts-ignore
+                method: 'signalwire.subscribe',
+                params: {
+                  event_channel: 'rooms',
+                  get_initial_state: true,
+                  events: ['room.started', 'room.ended'],
+                },
+              })
             } else {
               logger.warn(
                 '`consumer.run()` was called without any listeners attached.'

--- a/packages/node/src/createWebSocketClient.ts
+++ b/packages/node/src/createWebSocketClient.ts
@@ -22,9 +22,12 @@ export const createWebSocketClient = async (userOptions: UserOptions) => {
   const client: StrictEventEmitter<Client, ClientEvents> = connect({
     store,
     Component: Client,
-    onStateChangeListeners: {
+    componentListeners: {
       errors: 'onError',
       responses: 'onSuccess',
+    },
+    sessionListeners: {
+      authStatus: 'onAuth',
     },
   })(baseUserOptions)
 

--- a/packages/node/src/createWebSocketClient.ts
+++ b/packages/node/src/createWebSocketClient.ts
@@ -1,7 +1,7 @@
 import {
-  BaseClientOptions,
   ClientEvents,
   configureStore,
+  connect,
   getEventEmitter,
   UserOptions,
 } from '@signalwire/core'
@@ -10,7 +10,7 @@ import { Client } from './Client'
 import { Session } from './Session'
 
 export const createWebSocketClient = async (userOptions: UserOptions) => {
-  const baseUserOptions: BaseClientOptions = {
+  const baseUserOptions = {
     ...userOptions,
     emitter: getEventEmitter<ClientEvents>(userOptions),
   }
@@ -18,10 +18,16 @@ export const createWebSocketClient = async (userOptions: UserOptions) => {
     userOptions: baseUserOptions,
     SessionConstructor: Session,
   })
-  const client: StrictEventEmitter<Client, ClientEvents> = new Client(
-    baseUserOptions,
-    store
-  )
+
+  const client: StrictEventEmitter<Client, ClientEvents> = connect({
+    store,
+    Component: Client,
+    onStateChangeListeners: {
+      errors: 'onError',
+      responses: 'onSuccess',
+    },
+  })(baseUserOptions)
+
   if (baseUserOptions.autoConnect) {
     await client.connect()
   }


### PR DESCRIPTION
The code in this changeset includes:

* Add Consumer API for listening for `room.started` and `room.created` in Node
* Updated `connect` to support `component` and `session` level listeners