### PR TITLE
Allow Screen Sharing 

### DIFF
--- a/.changeset/early-melons-fix.md
+++ b/.changeset/early-melons-fix.md
@@ -1,0 +1,7 @@
+---
+'@signalwire/core': patch
+'@signalwire/js': patch
+'@signalwire/webrtc': patch
+---
+
+Expose createScreenShareObject() method to share the screen in a room

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -218,6 +218,7 @@ interface RoomMemberProperties {
   output_volume: number
   on_hold: boolean
   deaf: boolean
+  // FIXME: review this for different types
   type: RoomMemberType
   visible: boolean
   audio_muted: boolean

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -205,6 +205,7 @@ export interface RoomMemberLocation {
   width: number
 }
 
+type RoomMemberType = 'member' | 'screen'
 interface RoomMemberCommon {
   id: string
   room_session_id: string
@@ -217,7 +218,7 @@ interface RoomMemberProperties {
   output_volume: number
   on_hold: boolean
   deaf: boolean
-  type: 'member'
+  type: RoomMemberType
   visible: boolean
   audio_muted: boolean
   video_muted: boolean
@@ -225,7 +226,14 @@ interface RoomMemberProperties {
   location: RoomMemberLocation
 }
 
-export type RoomMember = RoomMemberCommon & RoomMemberProperties
+export type RoomMember = RoomMemberCommon &
+  RoomMemberProperties & {
+    type: 'member'
+  }
+export type RoomScreenShare = RoomMember & {
+  parent_id: string
+  type: 'screen'
+}
 
 export interface Room {
   blind_mode: boolean

--- a/packages/js/src/Client.ts
+++ b/packages/js/src/Client.ts
@@ -1,14 +1,11 @@
 import { connect, BaseClient } from '@signalwire/core'
-import { Call, CallEvents, CallOptions } from '@signalwire/webrtc'
-import StrictEventEmitter from 'strict-event-emitter-types'
+import { Call, CallOptions, RoomObject } from '@signalwire/webrtc'
 import { videoElementFactory } from './utils/videoElementFactory'
 
 interface MakeCallOptions extends CallOptions {
   rootElementId?: string
   applyLocalVideoOverlay?: boolean
 }
-
-export type RoomObject = StrictEventEmitter<Call, CallEvents>
 
 export class Client extends BaseClient {
   get rooms() {

--- a/packages/js/src/createRoomObject.ts
+++ b/packages/js/src/createRoomObject.ts
@@ -1,5 +1,5 @@
 import { logger, UserOptions } from '@signalwire/core'
-import { RoomObject } from './Client'
+import { RoomObject } from '@signalwire/webrtc'
 import { createClient } from './createClient'
 import { videoElementFactory } from './utils/videoElementFactory'
 

--- a/packages/js/src/video.ts
+++ b/packages/js/src/video.ts
@@ -5,5 +5,5 @@ import { Client } from './Client'
 
 export { Client, createClient, createRoomObject, joinRoom }
 
-export type { RoomObject } from './Client'
+export type { RoomObject } from '@signalwire/webrtc'
 export type { CreateRoomObjectOptions } from './createRoomObject'

--- a/packages/webrtc/src/BaseCall.ts
+++ b/packages/webrtc/src/BaseCall.ts
@@ -77,7 +77,6 @@ export class BaseCall extends BaseComponent {
       options?.iceServers ?? this.select(selectors.getIceServers)
 
     this.options = {
-      id: this.id,
       ...DEFAULT_CALL_OPTIONS,
       ...options,
       iceServers,
@@ -122,7 +121,6 @@ export class BaseCall extends BaseComponent {
 
   get messagePayload() {
     const {
-      id,
       destinationNumber,
       attach,
       callerName,
@@ -135,7 +133,7 @@ export class BaseCall extends BaseComponent {
     return {
       sessid: this.options.sessionid,
       dialogParams: {
-        id,
+        id: this.id,
         destinationNumber,
         attach,
         callerName,
@@ -366,7 +364,7 @@ export class BaseCall extends BaseComponent {
         break
       default:
         return logger.error(
-          `Unknown SDP type: '${type}' on call ${this.options.id}`
+          `Unknown SDP type: '${type}' on call ${this.id}`
         )
     }
   }

--- a/packages/webrtc/src/BaseCall.ts
+++ b/packages/webrtc/src/BaseCall.ts
@@ -44,7 +44,7 @@ interface MemberCommandWithVolumeParams extends MemberCommandParams {
 interface MemberCommandWithValueParams extends MemberCommandParams {
   value: number
 }
-type BaseCallOptions = CallOptions & BaseComponentOptions
+export type BaseCallOptions = CallOptions & BaseComponentOptions
 export class BaseCall extends BaseComponent {
   public nodeId = ''
   public direction: 'inbound' | 'outbound'

--- a/packages/webrtc/src/BaseCall.ts
+++ b/packages/webrtc/src/BaseCall.ts
@@ -53,8 +53,6 @@ export class BaseCall extends BaseComponent {
   public cause: string
   public causeCode: string
   public gotEarly = false
-  public screenShare?: BaseCall
-  public secondSource?: BaseCall
   public doReinvite = false
   public isDirect = false
   public videoElements: HTMLVideoElement[] = []
@@ -367,9 +365,7 @@ export class BaseCall extends BaseComponent {
         // this.executeAnswer()
         break
       default:
-        return logger.error(
-          `Unknown SDP type: '${type}' on call ${this.id}`
-        )
+        return logger.error(`Unknown SDP type: '${type}' on call ${this.id}`)
     }
   }
 
@@ -499,22 +495,10 @@ export class BaseCall extends BaseComponent {
 
     switch (state) {
       case 'purge': {
-        if (this.screenShare instanceof BaseCall) {
-          this.screenShare.setState('purge')
-        }
-        if (this.secondSource instanceof BaseCall) {
-          this.secondSource.setState('purge')
-        }
         this._finalize()
         break
       }
       case 'hangup': {
-        if (this.screenShare instanceof BaseCall) {
-          this.screenShare.hangup()
-        }
-        if (this.secondSource instanceof BaseCall) {
-          this.secondSource.hangup()
-        }
         this.setState('destroy')
         break
       }

--- a/packages/webrtc/src/BaseCall.ts
+++ b/packages/webrtc/src/BaseCall.ts
@@ -202,7 +202,11 @@ export class BaseCall extends BaseComponent {
       node_id: this.nodeId,
     }
     if (vertoMessage.method === VertoMethod.Invite) {
-      params.subscribe = ROOM_EVENTS
+      if (this.options.screenShare) {
+        params.subscribe = ['room.screenshare']
+      } else {
+        params.subscribe = ROOM_EVENTS
+      }
     }
 
     return this.execute({

--- a/packages/webrtc/src/Call.ts
+++ b/packages/webrtc/src/Call.ts
@@ -1,7 +1,35 @@
-import { BaseCall } from './BaseCall'
+import { logger } from '@signalwire/core'
+import { getDisplayMedia } from '@signalwire/webrtc'
+import { BaseCall, BaseCallOptions } from './BaseCall'
 
 export class Call extends BaseCall {
-  desktopOnlyMethod() {
-    console.debug('Desktop Method')
+
+  async startScreenShare(opts?: BaseCallOptions) {
+    const { audio = false, video = true } = (opts || {})
+    const displayStream: MediaStream = await getDisplayMedia({ audio, video })
+    displayStream.getTracks().forEach(t => {
+      t.addEventListener('ended', () => {
+        if (this.screenShare) {
+          this.screenShare.hangup()
+        }
+      })
+    })
+    const options: BaseCallOptions = {
+      ...this.options,
+      screenShare: true,
+      recoverCall: false,
+      skipLiveArray: true,
+      localStream: displayStream,
+      ...opts,
+      destinationNumber: 'edoRoom2',
+    }
+    this.screenShare = new Call(options)
+    try {
+      await this.screenShare.invite()
+      return this.screenShare
+    } catch (error) {
+      logger.error('ScreenShare Error', error)
+      throw error
+    }
   }
 }

--- a/packages/webrtc/src/Call.ts
+++ b/packages/webrtc/src/Call.ts
@@ -1,19 +1,18 @@
 import { logger, connect, getEventEmitter } from '@signalwire/core'
 import { getDisplayMedia } from './utils/webrtcHelpers'
+import { RoomObject, StartScreenShareOptions } from './utils/interfaces'
 import { BaseCall, BaseCallOptions } from './BaseCall'
 
-type StartScreenShareOptions = {
-  audio?: MediaStreamConstraints['audio']
-  video?: MediaStreamConstraints['video']
-}
-
 export class Call extends BaseCall {
-  private _screenShareList = new Set<Call>()
+  private _screenShareList = new Set<RoomObject>()
 
   get screenShareList() {
     return Array.from(this._screenShareList)
   }
 
+  /**
+   * Allow sharing the screen within the room.
+   */
   async startScreenShare(opts: StartScreenShareOptions = {}) {
     const { audio = false, video = true } = opts
     const displayStream: MediaStream = await getDisplayMedia({ audio, video })
@@ -29,7 +28,7 @@ export class Call extends BaseCall {
       emitter: fakeEmitter,
     }
 
-    const screenShare = connect({
+    const screenShare: RoomObject = connect({
       store: this.store,
       Component: Call,
       onStateChangeListeners: {

--- a/packages/webrtc/src/Call.ts
+++ b/packages/webrtc/src/Call.ts
@@ -1,13 +1,12 @@
 import { logger, connect, getEventEmitter } from '@signalwire/core'
-import { getDisplayMedia } from '@signalwire/webrtc'
+import { getDisplayMedia } from './utils/webrtcHelpers'
 import { BaseCall, BaseCallOptions } from './BaseCall'
 
 export class Call extends BaseCall {
-
   async startScreenShare(opts?: BaseCallOptions) {
-    const { audio = false, video = true } = (opts || {})
+    const { audio = false, video = true } = opts || {}
     const displayStream: MediaStream = await getDisplayMedia({ audio, video })
-    displayStream.getTracks().forEach(t => {
+    displayStream.getTracks().forEach((t) => {
       t.addEventListener('ended', () => {
         if (this.screenShare) {
           this.screenShare.hangup()

--- a/packages/webrtc/src/Call.ts
+++ b/packages/webrtc/src/Call.ts
@@ -1,6 +1,6 @@
 import { logger, connect, getEventEmitter } from '@signalwire/core'
 import { getDisplayMedia } from './utils/webrtcHelpers'
-import { RoomObject, StartScreenShareOptions } from './utils/interfaces'
+import { RoomObject, CreateScreenShareObjectOptions } from './utils/interfaces'
 import { BaseCall, BaseCallOptions } from './BaseCall'
 
 export class Call extends BaseCall {
@@ -13,7 +13,7 @@ export class Call extends BaseCall {
   /**
    * Allow sharing the screen within the room.
    */
-  async startScreenShare(opts: StartScreenShareOptions = {}) {
+  async createScreenShareObject(opts: CreateScreenShareObjectOptions = {}) {
     const { audio = false, video = true } = opts
     const displayStream: MediaStream = await getDisplayMedia({ audio, video })
 

--- a/packages/webrtc/src/RTCPeer.ts
+++ b/packages/webrtc/src/RTCPeer.ts
@@ -196,7 +196,7 @@ export default class RTCPeer {
         return logger.info('No sender to apply constraints', kind, constraints)
       }
       if (sender.track.readyState === 'live') {
-        logger.info(`Apply ${kind} constraints`, this.options.id, constraints)
+        logger.info(`Apply ${kind} constraints`, this.call.id, constraints)
         await sender.track.applyConstraints(constraints)
       }
     } catch (error) {
@@ -268,7 +268,7 @@ export default class RTCPeer {
       await this._setRemoteDescription({ sdp, type })
     } catch (error) {
       logger.error(
-        `Error handling remote SDP on call ${this.options.id}:`,
+        `Error handling remote SDP on call ${this.call.id}:`,
         error
       )
       this.call.hangup()

--- a/packages/webrtc/src/utils/interfaces.ts
+++ b/packages/webrtc/src/utils/interfaces.ts
@@ -14,7 +14,6 @@ export interface CallOptions {
   callerNumber: string
   // Optional
   sessionid?: string
-  id?: string
   remoteSdp?: string
   localStream?: MediaStream
   remoteStream?: MediaStream

--- a/packages/webrtc/src/utils/interfaces.ts
+++ b/packages/webrtc/src/utils/interfaces.ts
@@ -62,7 +62,7 @@ export type CallEvents = {
 
 export type RoomObject = StrictEventEmitter<Call, CallEvents>
 
-export type StartScreenShareOptions = {
+export type CreateScreenShareObjectOptions = {
   audio?: MediaStreamConstraints['audio']
   video?: MediaStreamConstraints['video']
 }

--- a/packages/webrtc/src/utils/interfaces.ts
+++ b/packages/webrtc/src/utils/interfaces.ts
@@ -1,3 +1,4 @@
+import StrictEventEmitter from 'strict-event-emitter-types'
 import type {
   CallEventNames,
   CallState,
@@ -57,4 +58,11 @@ type CallEventsHandlerMapping = EventsHandlerMapping &
 
 export type CallEvents = {
   [k in CallEventNames | CallState]: CallEventsHandlerMapping[k]
+}
+
+export type RoomObject = StrictEventEmitter<Call, CallEvents>
+
+export type StartScreenShareOptions = {
+  audio?: MediaStreamConstraints['audio']
+  video?: MediaStreamConstraints['video']
 }


### PR DESCRIPTION
This PR adds the ability to share the screen within a room. The "screenShare" will be a room member so it trigger `member.joined` and all the other events like a normal user in the room but has a specific `type: "screen"` and also a `parent_id` that is the relation with the user that is sharing.

Ref https://github.com/signalwire/cloud-product/issues/1657