### PR TITLE
`execute` queueing + reconnect logic

### DIFF
--- a/.changeset/nice-turkeys-sort.md
+++ b/.changeset/nice-turkeys-sort.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/node': patch
+---
+
+Remove internal queueing mechanism for executing actions.

--- a/.changeset/silly-feet-doubt.md
+++ b/.changeset/silly-feet-doubt.md
@@ -1,0 +1,7 @@
+---
+'@signalwire/core': patch
+---
+
+Add ability to queue execute actions based on the user's auth status.
+Add ability to track how many times the user has been reconnected.
+Improve reconnecting logic.

--- a/packages/core/src/BaseSession.ts
+++ b/packages/core/src/BaseSession.ts
@@ -31,7 +31,9 @@ import {
   socketClosed,
   socketError,
   socketMessage,
+  closeConnectionAction,
 } from './redux/actions'
+import { sessionActions } from './redux/features/session/sessionSlice'
 
 export class BaseSession {
   public uuid = uuid()
@@ -310,6 +312,8 @@ export class BaseSession {
     status: Extract<SessionStatus, 'reconnecting' | 'disconnected'>
   ) {
     this._status = status
+    this.dispatch(sessionActions.authStatus('unknown'))
+    this.dispatch(closeConnectionAction())
     if (this._socket) {
       this._socket.close()
       this._socket = null

--- a/packages/core/src/redux/actions.ts
+++ b/packages/core/src/redux/actions.ts
@@ -8,6 +8,7 @@ import { ExecuteActionParams } from './interfaces'
 
 export const initAction = createAction('swSdk/init')
 export const destroyAction = createAction('swSdk/destroy')
+export const closeConnectionAction = createAction('swSdk/closeConnection')
 
 /**
  * Trigger saga to send a blade.execute over the wire

--- a/packages/core/src/redux/features/executeQueue/executeQueueSaga.test.ts
+++ b/packages/core/src/redux/features/executeQueue/executeQueueSaga.test.ts
@@ -1,0 +1,64 @@
+import { Store } from 'redux'
+import { expectSaga } from 'redux-saga-test-plan'
+import { executeQueueWatcher } from './executeQueueSaga'
+import { executeQueueActions } from './executeQueueSlice'
+import { ExecuteActionParams } from '../../interfaces'
+import { executeAction } from '../../actions'
+import { rootReducer } from '../../rootReducer'
+import { configureJestStore } from '../../../testUtils'
+import { sessionActions } from '../session/sessionSlice'
+
+describe('executeQueueWatcher', () => {
+  let store: Store
+
+  beforeEach(() => {
+    store = configureJestStore()
+  })
+
+  it('should listen for executeAction.type and add them to the queue if the user is not authenticated', () => {
+    const payload: ExecuteActionParams = {
+      method: 'signalwire.subscribe',
+      params: {
+        event_channel: 'rooms',
+        get_initial_state: true,
+        events: ['room.started', 'room.ended'],
+      },
+    }
+
+    return expectSaga(executeQueueWatcher)
+      .withReducer(rootReducer)
+      .put(executeQueueActions.add(payload))
+      .dispatch(executeAction(payload))
+      .hasFinalState({
+        ...store.getState(),
+        executeQueue: { queue: [payload] },
+      })
+      .silentRun()
+  })
+
+  it('should not add executeAction.type to the queue when the user is authenticated', () => {
+    const payload: ExecuteActionParams = {
+      method: 'signalwire.subscribe',
+      params: {
+        event_channel: 'rooms',
+        get_initial_state: true,
+        events: ['room.started', 'room.ended'],
+      },
+    }
+    const state = store.getState()
+
+    return expectSaga(executeQueueWatcher)
+      .withReducer(rootReducer)
+      .dispatch(sessionActions.connected({} as any))
+      .dispatch(executeAction(payload))
+      .hasFinalState({
+        ...state,
+        session: {
+          ...state.session,
+          authStatus: 'authorized',
+          authCount: 1,
+        },
+      })
+      .silentRun()
+  })
+})

--- a/packages/core/src/redux/features/executeQueue/executeQueueSaga.ts
+++ b/packages/core/src/redux/features/executeQueue/executeQueueSaga.ts
@@ -1,0 +1,40 @@
+import { SagaIterator } from 'redux-saga'
+import { put, take, fork, select } from 'redux-saga/effects'
+import { PayloadAction } from '@reduxjs/toolkit'
+import { ExecuteActionParams } from '../../interfaces'
+import { getAuthStatus } from '../session/sessionSelectors'
+import { SessionAuthStatus } from '../../../utils/interfaces'
+import { executeAction } from '../../actions'
+import { getExecuteQueue } from './executeQueueSelectors'
+import { executeQueueActions } from './executeQueueSlice'
+
+export function* executeQueueWatcher(): SagaIterator {
+  function* worker(action: PayloadAction<ExecuteActionParams>): SagaIterator {
+    const authStatus: SessionAuthStatus = yield select(getAuthStatus)
+
+    console.log('authStatus', authStatus)
+
+    if (authStatus !== 'authorized') {
+      console.log('METO EN LA QUEUE', action.payload)
+
+      yield put(executeQueueActions.add(action.payload))
+    }
+  }
+
+  while (true) {
+    const action = yield take(executeAction.type)
+    yield fork(worker, action)
+  }
+}
+
+export function* executeQueueCallWorker(): SagaIterator {
+  const { queue } = yield select(getExecuteQueue)
+
+  console.log('-------------> queue', queue)
+
+  for (const params of queue) {
+    yield put(executeAction(params))
+  }
+
+  yield put(executeQueueActions.clean())
+}

--- a/packages/core/src/redux/features/executeQueue/executeQueueSaga.ts
+++ b/packages/core/src/redux/features/executeQueue/executeQueueSaga.ts
@@ -22,7 +22,7 @@ export function* executeQueueWatcher(): SagaIterator {
   }
 }
 
-export function* executeQueueCallWorker(): SagaIterator {
+export function* flushExecuteQueueWorker(): SagaIterator {
   const { queue } = yield select(getExecuteQueue)
   for (const params of queue) {
     yield put(executeAction(params))

--- a/packages/core/src/redux/features/executeQueue/executeQueueSaga.ts
+++ b/packages/core/src/redux/features/executeQueue/executeQueueSaga.ts
@@ -11,12 +11,7 @@ import { executeQueueActions } from './executeQueueSlice'
 export function* executeQueueWatcher(): SagaIterator {
   function* worker(action: PayloadAction<ExecuteActionParams>): SagaIterator {
     const authStatus: SessionAuthStatus = yield select(getAuthStatus)
-
-    console.log('authStatus', authStatus)
-
     if (authStatus !== 'authorized') {
-      console.log('METO EN LA QUEUE', action.payload)
-
       yield put(executeQueueActions.add(action.payload))
     }
   }
@@ -29,12 +24,8 @@ export function* executeQueueWatcher(): SagaIterator {
 
 export function* executeQueueCallWorker(): SagaIterator {
   const { queue } = yield select(getExecuteQueue)
-
-  console.log('-------------> queue', queue)
-
   for (const params of queue) {
     yield put(executeAction(params))
   }
-
   yield put(executeQueueActions.clean())
 }

--- a/packages/core/src/redux/features/executeQueue/executeQueueSelectors.ts
+++ b/packages/core/src/redux/features/executeQueue/executeQueueSelectors.ts
@@ -1,0 +1,5 @@
+import { SDKState } from '../../interfaces'
+
+export const getExecuteQueue = ({ executeQueue }: SDKState) => {
+  return executeQueue
+}

--- a/packages/core/src/redux/features/executeQueue/executeQueueSlice.test.ts
+++ b/packages/core/src/redux/features/executeQueue/executeQueueSlice.test.ts
@@ -1,0 +1,50 @@
+import { Store } from 'redux'
+import { configureJestStore } from '../../../testUtils'
+import {
+  executeQueueActions,
+  initialExecuteQueueState,
+} from './executeQueueSlice'
+import { ExecuteActionParams } from '../../interfaces'
+import { destroyAction } from '../../actions'
+
+describe('ExecuteQueueState Tests', () => {
+  let store: Store
+
+  beforeEach(() => {
+    store = configureJestStore()
+  })
+
+  it('should add ExecuteParams to the queue on executeQueueActions.add action and reset it on executeQueueActions.add action', () => {
+    const payload: ExecuteActionParams = {
+      method: 'signalwire.subscribe',
+      params: {
+        event_channel: 'rooms',
+        get_initial_state: true,
+        events: ['room.started', 'room.ended'],
+      },
+    }
+
+    store.dispatch(executeQueueActions.add(payload))
+    expect(store.getState().executeQueue.queue).toStrictEqual([payload])
+
+    store.dispatch(executeQueueActions.clean())
+    expect(store.getState().executeQueue.queue).toStrictEqual([])
+  })
+
+  it('should reset to initial on destroyAction', () => {
+    const payload: ExecuteActionParams = {
+      method: 'signalwire.subscribe',
+      params: {
+        event_channel: 'rooms',
+        get_initial_state: true,
+        events: ['room.started', 'room.ended'],
+      },
+    }
+    store.dispatch(executeQueueActions.add(payload))
+
+    store.dispatch(destroyAction())
+    expect(store.getState().executeQueue).toStrictEqual(
+      initialExecuteQueueState
+    )
+  })
+})

--- a/packages/core/src/redux/features/executeQueue/executeQueueSlice.ts
+++ b/packages/core/src/redux/features/executeQueue/executeQueueSlice.ts
@@ -11,6 +11,9 @@ const executeQueueSlice = createSlice({
   initialState: initialExecuteQueueState,
   reducers: {
     add: (state, { payload }: PayloadAction<ExecuteActionParams>) => {
+      // TODO: Do we have to check for something (like an item in
+      // queue with the same `payload.method`?) before adding the
+      // payload to the queue?
       state.queue.push(payload)
     },
     clean: () => {

--- a/packages/core/src/redux/features/executeQueue/executeQueueSlice.ts
+++ b/packages/core/src/redux/features/executeQueue/executeQueueSlice.ts
@@ -1,0 +1,31 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { ExecuteQueueState, ExecuteActionParams } from '../../interfaces'
+import { destroyAction } from '../../actions'
+
+export const initialExecuteQueueState: Readonly<ExecuteQueueState> = {
+  queue: [],
+}
+
+const executeQueueSlice = createSlice({
+  name: 'executeQueue',
+  initialState: initialExecuteQueueState,
+  reducers: {
+    add: (state, { payload }: PayloadAction<ExecuteActionParams>) => {
+      state.queue.push(payload)
+    },
+    clean: () => {
+      return initialExecuteQueueState
+    },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(destroyAction.type, () => {
+      return initialExecuteQueueState
+    })
+  },
+})
+
+// prettier-ignore
+export const {
+  actions: executeQueueActions,
+  reducer: executeQueueReducer
+} = executeQueueSlice

--- a/packages/core/src/redux/features/index.ts
+++ b/packages/core/src/redux/features/index.ts
@@ -1,2 +1,3 @@
 export * from './component/componentSlice'
+export * from './executeQueue/executeQueueSlice'
 export * from './session/sessionSlice'

--- a/packages/core/src/redux/features/session/sessionSaga.ts
+++ b/packages/core/src/redux/features/session/sessionSaga.ts
@@ -1,5 +1,5 @@
 import { SagaIterator, Channel, eventChannel, EventChannel } from 'redux-saga'
-import { call, put, take, fork } from 'redux-saga/effects'
+import { call, put, take, fork, select } from 'redux-saga/effects'
 import { PayloadAction } from '@reduxjs/toolkit'
 import { BaseSession } from '../../../BaseSession'
 import { VertoResult } from '../../../RPCMessages'
@@ -14,6 +14,8 @@ import { componentActions } from '../'
 import { BladeMethod, VertoMethod } from '../../../utils/constants'
 import { BladeExecute } from '../../../RPCMessages'
 import { logger } from '../../../utils'
+import { getAuthStatus } from '../session/sessionSelectors'
+import { SessionAuthStatus } from '../../../utils/interfaces'
 
 type SessionSagaParams = {
   session: BaseSession
@@ -69,7 +71,11 @@ export function* executeActionWatcher(session: BaseSession): SagaIterator {
 
   while (true) {
     const action = yield take(executeAction.type)
-    yield fork(worker, action)
+    const authStatus: SessionAuthStatus = yield select(getAuthStatus)
+
+    if (authStatus === 'authorized') {
+      yield fork(worker, action)
+    }
   }
 }
 

--- a/packages/core/src/redux/features/session/sessionSlice.test.ts
+++ b/packages/core/src/redux/features/session/sessionSlice.test.ts
@@ -18,6 +18,7 @@ describe('SessionState Tests', () => {
       iceServers: bladeConnectResultVRT.result?.iceServers,
       authStatus: 'authorized',
       authError: undefined,
+      authCount: 1,
     })
   })
 

--- a/packages/core/src/redux/features/session/sessionSlice.ts
+++ b/packages/core/src/redux/features/session/sessionSlice.ts
@@ -3,6 +3,7 @@ import { SessionState } from '../../interfaces'
 import {
   IBladeConnectResult,
   SessionAuthError,
+  SessionAuthStatus,
 } from '../../../utils/interfaces'
 import { destroyAction, authError } from '../../actions'
 
@@ -21,6 +22,9 @@ const sessionSlice = createSlice({
       state.authStatus = 'authorized'
       state.protocol = payload?.result?.protocol ?? ''
       state.iceServers = payload?.result?.iceServers ?? []
+    },
+    authStatus: (state, { payload }: PayloadAction<SessionAuthStatus>) => {
+      state.authStatus = payload
     },
   },
   extraReducers: (builder) => {

--- a/packages/core/src/redux/features/session/sessionSlice.ts
+++ b/packages/core/src/redux/features/session/sessionSlice.ts
@@ -12,6 +12,7 @@ export const initialSessionState: Readonly<SessionState> = {
   iceServers: [],
   authStatus: 'unknown',
   authError: undefined,
+  authCount: 0,
 }
 
 const sessionSlice = createSlice({
@@ -20,6 +21,7 @@ const sessionSlice = createSlice({
   reducers: {
     connected: (state, { payload }: PayloadAction<IBladeConnectResult>) => {
       state.authStatus = 'authorized'
+      state.authCount += 1
       state.protocol = payload?.result?.protocol ?? ''
       state.iceServers = payload?.result?.iceServers ?? []
     },

--- a/packages/core/src/redux/interfaces.ts
+++ b/packages/core/src/redux/interfaces.ts
@@ -45,6 +45,7 @@ export interface SessionState {
   iceServers?: RTCIceServer[]
   authStatus: SessionAuthStatus
   authError?: SessionAuthError
+  authCount: number
 }
 
 export interface SDKState {

--- a/packages/core/src/redux/interfaces.ts
+++ b/packages/core/src/redux/interfaces.ts
@@ -50,6 +50,7 @@ export interface SessionState {
 export interface SDKState {
   components: ComponentState
   session: SessionState
+  executeQueue: ExecuteQueueState
 }
 
 export interface ExecuteActionParams {
@@ -57,4 +58,8 @@ export interface ExecuteActionParams {
   componentId?: string
   method: BladeExecuteMethod
   params: Record<string, any>
+}
+
+export interface ExecuteQueueState {
+  queue: ExecuteActionParams[]
 }

--- a/packages/core/src/redux/rootReducer.ts
+++ b/packages/core/src/redux/rootReducer.ts
@@ -1,7 +1,12 @@
 import { combineReducers } from '@reduxjs/toolkit'
-import { componentReducer, sessionReducer } from './features'
+import {
+  componentReducer,
+  sessionReducer,
+  executeQueueReducer,
+} from './features'
 
 export const rootReducer = combineReducers({
   components: componentReducer,
   session: sessionReducer,
+  executeQueue: executeQueueReducer,
 })

--- a/packages/core/src/redux/rootSaga.test.ts
+++ b/packages/core/src/redux/rootSaga.test.ts
@@ -13,7 +13,7 @@ import {
 } from './features/session/sessionSaga'
 import {
   executeQueueWatcher,
-  executeQueueCallWorker,
+  flushExecuteQueueWorker,
 } from './features/executeQueue/executeQueueSaga'
 import { pubSubSaga } from './features/pubSub/pubSubSaga'
 import { sessionActions } from './features'
@@ -203,7 +203,7 @@ describe('startSaga', () => {
       .put(sessionActions.connected(session.bladeConnectResult))
     saga.next().put(pubSubChannel, sessionConnected())
 
-    saga.next().fork(executeQueueCallWorker)
+    saga.next().fork(flushExecuteQueueWorker)
 
     saga.next(executeQueueCallTask).take(closeConnectionAction.type)
     saga.next().isDone()

--- a/packages/core/src/redux/rootSaga.ts
+++ b/packages/core/src/redux/rootSaga.ts
@@ -70,7 +70,6 @@ export function* initSessionSaga(
   yield take(destroyAction.type)
   pubSubChannel.close()
   sessionChannel.close()
-  pubSubChannel.close()
 }
 
 export function* socketClosedWorker({

--- a/packages/core/src/redux/rootSaga.ts
+++ b/packages/core/src/redux/rootSaga.ts
@@ -131,14 +131,14 @@ export function* startSaga(options: StartSagaOptions): SagaIterator {
    */
   const executeActionTask: Task = yield fork(executeActionWatcher, session)
 
+  yield put(sessionActions.connected(session.bladeConnectResult))
+  yield put(pubSubChannel, sessionConnected())
+
   /**
    * Will take care of executing any pending blade.execute we have in
    * the queue
    */
   const executeQueueCallTask: Task = yield fork(executeQueueCallWorker)
-
-  yield put(sessionActions.connected(session.bladeConnectResult))
-  yield put(pubSubChannel, sessionConnected())
 
   /**
    * Wait for a destroyAction to teardown all the things

--- a/packages/core/src/redux/rootSaga.ts
+++ b/packages/core/src/redux/rootSaga.ts
@@ -9,7 +9,7 @@ import {
 } from './features/session/sessionSaga'
 import { pubSubSaga } from './features/pubSub/pubSubSaga'
 import {
-  executeQueueCallWorker,
+  flushExecuteQueueWorker,
   executeQueueWatcher,
 } from './features/executeQueue/executeQueueSaga'
 import {
@@ -143,7 +143,7 @@ export function* startSaga(options: StartSagaOptions): SagaIterator {
    * Will take care of executing any pending blade.execute we have in
    * the queue
    */
-  const executeQueueCallTask: Task = yield fork(executeQueueCallWorker)
+  const flushExecuteQueueTask: Task = yield fork(flushExecuteQueueWorker)
 
   /**
    * When `closeConnectionAction` is dispatched we'll teardown all the
@@ -154,7 +154,7 @@ export function* startSaga(options: StartSagaOptions): SagaIterator {
 
   pubSubTask.cancel()
   executeActionTask.cancel()
-  executeQueueCallTask.cancel()
+  flushExecuteQueueTask.cancel()
 }
 
 interface RootSagaOptions {

--- a/packages/node/src/Client.ts
+++ b/packages/node/src/Client.ts
@@ -16,7 +16,6 @@ export class Client extends BaseClient {
   private _consumers: Consumer[] = []
 
   async onAuth(session: SessionState) {
-    console.log('=> onAuth Client', session.authStatus)
     if (session.authStatus === 'authorized' && session.authCount > 1) {
       this._consumers.forEach((consumer) => {
         consumer.run()

--- a/packages/node/src/Client.ts
+++ b/packages/node/src/Client.ts
@@ -13,12 +13,12 @@ interface Consumer {
   run: () => Promise<unknown>
 }
 export class Client extends BaseClient {
-  private consumers: Consumer[] = []
+  private _consumers: Consumer[] = []
 
   async onAuth(session: SessionState) {
     console.log('=> onAuth Client', session.authStatus)
     if (session.authStatus === 'authorized' && session.authCount > 1) {
-      this.consumers.forEach((consumer) => {
+      this._consumers.forEach((consumer) => {
         consumer.run()
       })
     }
@@ -66,7 +66,7 @@ export class Client extends BaseClient {
           },
         }
 
-        this.consumers.push(consumer)
+        this._consumers.push(consumer)
 
         return consumer
       },


### PR DESCRIPTION
The code in this changeset includes:

* Ability to queue execute actions based on the user's `authStatus` and unlock some features described in #166 
* Improved reconnecting logic. We now distinguish between cleaning up the app singletons (Session and PubSub channel) vs the things created by each `startSaga` every time the user reconnects
* Ability to track how many times the user has been reconnected.