### PR TITLE
Namespaced Emitters

### DIFF
--- a/.changeset/hip-lies-drive.md
+++ b/.changeset/hip-lies-drive.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/core': patch
+'@signalwire/webrtc': patch
+---
+
+Encapsulate each EventEmitter using the room session id as the namespace.

--- a/.changeset/hip-lies-drive.md
+++ b/.changeset/hip-lies-drive.md
@@ -3,4 +3,4 @@
 '@signalwire/webrtc': patch
 ---
 
-Encapsulate each EventEmitter using the room session id as the namespace.
+Encapsulate each EventEmitter using a unique id as the namespace.

--- a/packages/core/src/BaseClient.ts
+++ b/packages/core/src/BaseClient.ts
@@ -8,6 +8,10 @@ export class BaseClient extends BaseComponent {
     super(options)
   }
 
+  onClientSubscribed() {
+    this._attachListeners('')
+  }
+
   /**
    * Connect the underlay WebSocket connection to the SignalWire network.
    *

--- a/packages/core/src/BaseClient.ts
+++ b/packages/core/src/BaseClient.ts
@@ -8,7 +8,13 @@ export class BaseClient extends BaseComponent {
     super(options)
   }
 
-  onClientSubscribed() {
+  /**
+   * Starts the initialization process as soon as the Client has been
+   * registered in the Redux store.
+   *
+   * @internal
+   */
+  protected onClientSubscribed() {
     this._attachListeners('')
   }
 

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -5,6 +5,7 @@ import {
   BaseComponentOptions,
   Emitter,
 } from './utils/interfaces'
+import { getNamespacedEvent } from './utils/EventEmitter'
 import { SDKState } from './redux/interfaces'
 
 export class BaseComponent implements Emitter {
@@ -12,6 +13,16 @@ export class BaseComponent implements Emitter {
 
   private _requests = new Map()
   private _destroyer?: () => void
+  private _getNamespacedEvent(event: string | symbol) {
+    if (event && typeof event === 'string') {
+      return getNamespacedEvent({
+        namespace: this.id,
+        event,
+      })
+    }
+
+    return event
+  }
 
   constructor(public options: BaseComponentOptions) {}
 
@@ -30,24 +41,31 @@ export class BaseComponent implements Emitter {
     return this.options.emitter
   }
 
-  on(...params: Parameters<Emitter['on']>) {
-    return this.emitter.on(...params)
+  on(event: string | symbol, fn: (...args: any[]) => void, context?: any) {
+    return this.emitter.on(this._getNamespacedEvent(event), fn, context)
   }
 
-  once(...params: Parameters<Emitter['once']>) {
-    return this.emitter.once(...params)
+  once(event: string | symbol, fn: (...args: any[]) => void, context?: any) {
+    return this.emitter.once(this._getNamespacedEvent(event), fn, context)
   }
 
-  off(...params: Parameters<Emitter['off']>) {
-    return this.emitter.off(...params)
+  off(
+    event: string | symbol,
+    fn?: ((...args: any[]) => void) | undefined,
+    context?: any,
+    once?: boolean | undefined
+  ) {
+    return this.emitter.off(this._getNamespacedEvent(event), fn, context, once)
   }
 
-  emit(...params: Parameters<Emitter['emit']>) {
-    return this.emitter.emit(...params)
+  emit(event: string | symbol, ...args: any[]) {
+    return this.emitter.emit(this._getNamespacedEvent(event), ...args)
   }
 
-  removeAllListeners(...params: Parameters<Emitter['removeAllListeners']>) {
-    return this.emitter.removeAllListeners(...params)
+  removeAllListeners(event?: string | symbol | undefined) {
+    return this.emitter.removeAllListeners(
+      event ? this._getNamespacedEvent(event) : event
+    )
   }
 
   destroy() {

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -1,22 +1,43 @@
-import { uuid } from './utils'
+import { uuid, logger } from './utils'
 import { executeAction } from './redux'
 import {
   ExecuteParams,
   BaseComponentOptions,
   Emitter,
 } from './utils/interfaces'
-import { getNamespacedEvent } from './utils/EventEmitter'
+import { EventEmitter, getNamespacedEvent } from './utils/EventEmitter'
 import { SDKState } from './redux/interfaces'
 
 export class BaseComponent implements Emitter {
   id = uuid()
 
+  private _status: 'active' | 'inactive' = 'inactive'
+  private _eventsRegisterQueue = new Set<
+    | {
+        type: 'on'
+        params: Parameters<Emitter['on']>
+      }
+    | {
+        type: 'off'
+        params: Parameters<Emitter['off']>
+      }
+    | {
+        type: 'once'
+        params: Parameters<Emitter['once']>
+      }
+    | {
+        type: 'removeAllListeners'
+        params: Parameters<Emitter['removeAllListeners']>
+      }
+  >()
+  private _eventsEmitQueue = new Set<any>()
+  private _eventsNamespace: string
   private _requests = new Map()
   private _destroyer?: () => void
   private _getNamespacedEvent(event: string | symbol) {
     if (event && typeof event === 'string') {
       return getNamespacedEvent({
-        namespace: this.id,
+        namespace: this._eventsNamespace,
         event,
       })
     }
@@ -41,31 +62,69 @@ export class BaseComponent implements Emitter {
     return this.options.emitter
   }
 
-  on(event: string | symbol, fn: (...args: any[]) => void, context?: any) {
-    return this.emitter.on(this._getNamespacedEvent(event), fn, context)
+  on(...params: Parameters<Emitter['on']>) {
+    const [event, fn, context] = params
+
+    if (this._status === 'active') {
+      const namespacedEvent = this._getNamespacedEvent(event)
+      logger.debug('Registering event', namespacedEvent)
+      return this.emitter.on(namespacedEvent, fn, context)
+    }
+
+    logger.debug('Adding event to the register queue', { event, fn, context })
+    this._eventsRegisterQueue.add({ type: 'on', params })
+    return this.emitter as EventEmitter<string | symbol, any>
   }
 
-  once(event: string | symbol, fn: (...args: any[]) => void, context?: any) {
-    return this.emitter.once(this._getNamespacedEvent(event), fn, context)
+  once(...params: Parameters<Emitter['once']>) {
+    const [event, fn, context] = params
+    if (this._status === 'active') {
+      const namespacedEvent = this._getNamespacedEvent(event)
+      logger.debug('Registering event', namespacedEvent)
+      return this.emitter.once(namespacedEvent, fn, context)
+    }
+
+    logger.debug('Adding event to the register queue', { event, fn, context })
+    this._eventsRegisterQueue.add({ type: 'once', params })
+    return this.emitter as EventEmitter<string | symbol, any>
   }
 
-  off(
-    event: string | symbol,
-    fn?: ((...args: any[]) => void) | undefined,
-    context?: any,
-    once?: boolean | undefined
-  ) {
-    return this.emitter.off(this._getNamespacedEvent(event), fn, context, once)
+  off(...params: Parameters<Emitter['off']>) {
+    const [event, fn, context, once] = params
+    if (this._status === 'active') {
+      const namespacedEvent = this._getNamespacedEvent(event)
+      logger.debug('Registering event', namespacedEvent)
+      return this.emitter.off(namespacedEvent, fn, context, once)
+    }
+
+    logger.debug('Adding event to the register queue', { event, fn, context })
+    this._eventsRegisterQueue.add({ type: 'off', params })
+    return this.emitter as EventEmitter<string | symbol, any>
   }
 
   emit(event: string | symbol, ...args: any[]) {
-    return this.emitter.emit(this._getNamespacedEvent(event), ...args)
+    if (this._status === 'active') {
+      const namespacedEvent = this._getNamespacedEvent(event)
+      logger.debug('Adding to the emit queue', namespacedEvent)
+      return this.emitter.emit(namespacedEvent, ...args)
+    }
+
+    logger.debug('Adding to the emit queue', event)
+    this._eventsEmitQueue.add({ event, args })
+    return false
   }
 
-  removeAllListeners(event?: string | symbol | undefined) {
-    return this.emitter.removeAllListeners(
-      event ? this._getNamespacedEvent(event) : event
-    )
+  removeAllListeners(...params: Parameters<Emitter['removeAllListeners']>) {
+    const [event] = params
+    if (this._status === 'active') {
+      return this.emitter.removeAllListeners(
+        event ? this._getNamespacedEvent(event) : event
+      )
+    }
+
+    logger.debug('Adding event to the register queue', { event })
+    this._eventsRegisterQueue.add({ type: 'removeAllListeners', params })
+    return this.emitter as EventEmitter<string | symbol, any>
   }
 
   destroy() {
@@ -108,6 +167,30 @@ export class BaseComponent implements Emitter {
     this._requests.forEach((value, key) => {
       value.resolve(component.responses[key])
       this._requests.delete(key)
+    })
+  }
+
+  /** @internal */
+  onConnect(namespace: string) {
+    this._status = 'active'
+    this._eventsNamespace = namespace
+
+    this._eventsRegisterQueue.forEach((item) => {
+      if (item.type === 'removeAllListeners') {
+        const { type, params } = item
+        this[type](...params)
+      } else {
+        const { type, params } = item
+        // @ts-ignore
+        this[type](...params)
+      }
+      this._eventsRegisterQueue.delete(item)
+    })
+
+    this._eventsEmitQueue.forEach((item) => {
+      const { event, args } = item
+      this.emit(event, ...args)
+      this._eventsEmitQueue.delete(item)
     })
   }
 }

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -172,17 +172,20 @@ export class BaseComponent implements Emitter {
 
   /** @internal */
   onConnect(namespace: string) {
+    if (!namespace) {
+      logger.error('Tried to call `onConnect` without a `namespace`.')
+      return
+    }
+
     this._status = 'active'
     this._eventsNamespace = namespace
 
     this._eventsRegisterQueue.forEach((item) => {
       if (item.type === 'removeAllListeners') {
-        const { type, params } = item
-        this[type](...params)
+        this[item.type](...item.params)
       } else {
-        const { type, params } = item
         // @ts-ignore
-        this[type](...params)
+        this[item.type](...item.params)
       }
       this._eventsRegisterQueue.delete(item)
     })

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -189,12 +189,8 @@ export class BaseComponent implements Emitter {
   /** @internal */
   private flushEventsRegisterQueue() {
     this._eventsRegisterQueue.forEach((item) => {
-      if (item.type === 'removeAllListeners') {
-        this[item.type](...item.params)
-      } else {
-        // @ts-ignore
-        this[item.type](...item.params)
-      }
+      // @ts-ignore
+      this[item.type](...item.params)
       this._eventsRegisterQueue.delete(item)
     })
   }
@@ -215,9 +211,9 @@ export class BaseComponent implements Emitter {
   }
 
   /** @internal */
-  protected _attachListeners(namespace?: string) {
+  protected _attachListeners(namespace: string) {
     if (namespace === undefined) {
-      logger.error('Tried to call `onConnect` without a `namespace`.')
+      logger.error('Tried to call `_attachListeners` without a `namespace`.')
       return
     }
     this._eventsNamespace = namespace

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -34,7 +34,7 @@ export class BaseComponent implements Emitter {
   private _requests = new Map()
   private _destroyer?: () => void
   private _getNamespacedEvent(event: string | symbol) {
-    if (event && typeof event === 'string' && this._eventsNamespace) {
+    if (typeof event === 'string' && this._eventsNamespace !== undefined) {
       return getNamespacedEvent({
         namespace: this._eventsNamespace,
         event,
@@ -215,8 +215,8 @@ export class BaseComponent implements Emitter {
   }
 
   /** @internal */
-  protected _attachListeners(namespace: string) {
-    if (!namespace) {
+  protected _attachListeners(namespace?: string) {
+    if (namespace === undefined) {
       logger.error('Tried to call `onConnect` without a `namespace`.')
       return
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-import { uuid, logger } from './utils'
+import { uuid, logger, isGlobalEvent } from './utils'
 import { BaseSession } from './BaseSession'
 import { BaseJWTSession } from './BaseJWTSession'
 import { configureStore, connect } from './redux'
@@ -18,7 +18,8 @@ export {
   connect,
   configureStore,
   EventEmitter,
-  getEventEmitter
+  getEventEmitter,
+  isGlobalEvent
 }
 
 export * from './RPCMessages'

--- a/packages/core/src/redux/features/pubSub/pubSubSaga.ts
+++ b/packages/core/src/redux/features/pubSub/pubSubSaga.ts
@@ -1,5 +1,5 @@
 import { take } from 'redux-saga/effects'
-import { logger } from '../../../utils'
+import { logger, isGlobalEvent } from '../../../utils'
 import { getNamespacedEvent } from '../../../utils/EventEmitter'
 
 const findNamespaceInPayload = (payload?: any): string => {
@@ -17,6 +17,17 @@ export function* pubSubSaga({ pubSubChannel, emitter }: any) {
     const { type, payload } = yield take(pubSubChannel)
     try {
       const namespace = findNamespaceInPayload(payload)
+
+      /**
+       * There are events (like `room.started`/`room.ended`) that can
+       * be consumed from different places, like from a `roomObj`
+       * (namespaced Event Emitter) or from a `client`
+       * (non-namespaced/global Event Emitter) so we must trigger the
+       * event twice to reach everyone.
+       */
+      if (isGlobalEvent(type)) {
+        emitter.emit(type, payload)
+      }
 
       emitter.emit(
         getNamespacedEvent({

--- a/packages/core/src/redux/features/pubSub/pubSubSaga.ts
+++ b/packages/core/src/redux/features/pubSub/pubSubSaga.ts
@@ -4,8 +4,10 @@ import { getNamespacedEvent } from '../../../utils/EventEmitter'
 
 const findNamespaceInPayload = (payload?: any): string => {
   // TODO: Validate if this list is exhaustive
-  // Also: what's the difference between `call_id` and `payload?.member.room_id`
-  const ns = payload?.call_id || payload?.member?.id
+  const ns =
+    payload?.room?.room_session_id ||
+    payload?.member?.room_session_id ||
+    payload?.layout?.room_session_id
 
   return ns || ''
 }
@@ -14,8 +16,6 @@ export function* pubSubSaga({ pubSubChannel, emitter }: any) {
   while (true) {
     const { type, payload } = yield take(pubSubChannel)
     try {
-      // TODO: with this we're missing out `layout` events since we
-      // don't have a way to get a reference to the call id
       const namespace = findNamespaceInPayload(payload)
 
       emitter.emit(

--- a/packages/core/src/redux/features/pubSub/pubSubSaga.ts
+++ b/packages/core/src/redux/features/pubSub/pubSubSaga.ts
@@ -1,11 +1,30 @@
 import { take } from 'redux-saga/effects'
 import { logger } from '../../../utils'
+import { getNamespacedEvent } from '../../../utils/EventEmitter'
+
+const findNamespaceInPayload = (payload?: any): string => {
+  // TODO: Validate if this list is exhaustive
+  // Also: what's the difference between `call_id` and `payload?.member.room_id`
+  const ns = payload?.call_id || payload?.member?.id
+
+  return ns || ''
+}
 
 export function* pubSubSaga({ pubSubChannel, emitter }: any) {
   while (true) {
     const { type, payload } = yield take(pubSubChannel)
     try {
-      emitter.emit(type, payload)
+      // TODO: with this we're missing out `layout` events since we
+      // don't have a way to get a reference to the call id
+      const namespace = findNamespaceInPayload(payload)
+
+      emitter.emit(
+        getNamespacedEvent({
+          namespace,
+          event: type,
+        }),
+        payload
+      )
     } catch (error) {
       logger.error(error)
     }

--- a/packages/core/src/utils/EventEmitter.ts
+++ b/packages/core/src/utils/EventEmitter.ts
@@ -44,4 +44,18 @@ const getEventEmitter = <T>(userOptions: UserOptions) => {
   )
 }
 
-export { assertEventEmitter, EventEmitter, getEventEmitter }
+const getNamespacedEvent = ({
+  namespace,
+  event,
+}: {
+  namespace: string
+  event: string
+}) => {
+  if (!namespace) {
+    return event
+  }
+
+  return `${namespace}:${event}`
+}
+
+export { assertEventEmitter, EventEmitter, getEventEmitter, getNamespacedEvent }

--- a/packages/core/src/utils/constants.ts
+++ b/packages/core/src/utils/constants.ts
@@ -11,6 +11,8 @@ export enum WebSocketState {
   CLOSED = 3,
 }
 
+export const GLOBAL_VIDEO_EVENTS = ['room.started', 'room.ended'] as const
+
 export enum BladeMethod {
   Broadcast = 'blade.broadcast',
   Disconnect = 'blade.disconnect',

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,4 +1,5 @@
-import { STORAGE_PREFIX } from './constants'
+import { STORAGE_PREFIX, GLOBAL_VIDEO_EVENTS } from './constants'
+import { RoomEventNames } from './interfaces'
 
 export { v4 as uuid } from 'uuid'
 export { logger } from './logger'
@@ -45,4 +46,9 @@ export const timeoutPromise = (
       (_resolve, reject) => (timer = setTimeout(reject, time, exception))
     ),
   ]).finally(() => clearTimeout(timer))
+}
+
+export const isGlobalEvent = (event: RoomEventNames) => {
+  // @ts-ignore
+  return GLOBAL_VIDEO_EVENTS.includes(event)
 }

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -1,6 +1,7 @@
 import { Store } from 'redux'
 import type { EventEmitter } from '../utils/EventEmitter'
 import { BaseSession } from '../BaseSession'
+import { GLOBAL_VIDEO_EVENTS } from './constants'
 
 /**
  * Minimal interface the emitter must fulfill
@@ -397,3 +398,5 @@ export type ExecuteParams = {
   method: BladeExecuteMethod
   params: Record<string, any>
 }
+
+export type GlobalVideoEvents = typeof GLOBAL_VIDEO_EVENTS[number]

--- a/packages/js/examples/heroku/index.html
+++ b/packages/js/examples/heroku/index.html
@@ -118,7 +118,7 @@
             </div>
           </div>
           <div class="row py-2">
-            <div class="col-6">
+            <div class="col-4">
               <div class="btn-group w-100" role="group">
                 <button
                   id="muteSelfBtn"
@@ -138,7 +138,7 @@
                 </button>
               </div>
             </div>
-            <div class="col-6">
+            <div class="col-4">
               <div class="btn-group w-100" role="group">
                 <button
                   id="muteVideoSelfBtn"
@@ -155,6 +155,26 @@
                   disabled="true"
                 >
                   Video UnMute Self
+                </button>
+              </div>
+            </div>
+            <div class="col-4">
+              <div class="btn-group w-100" role="group">
+                <button
+                  id="hideScreenShareBtn"
+                  class="btn btn-warning px-3 mt-2 d-none"
+                  onClick="startScreenShare()"
+                  disabled="true"
+                >
+                  Start Screenshare
+                </button>
+                <button
+                  id="showScreenShareBtn"
+                  class="btn btn-warning px-3 mt-2 d-none"
+                  onClick="stopScreenShare()"
+                  disabled="true"
+                >
+                  Stop Screenshare
                 </button>
               </div>
             </div>
@@ -249,11 +269,13 @@
 
           <div id="controlLayout" class="row py-2 d-none">
             <div class="col-4">
-              <label for="layout" class="form-label">
-                Change Layout
-              </label>
-              <select class="form-select" onchange="changeLayout(this)" value="" id="layout">
-              </select>
+              <label for="layout" class="form-label"> Change Layout </label>
+              <select
+                class="form-select"
+                onchange="changeLayout(this)"
+                value=""
+                id="layout"
+              ></select>
             </div>
           </div>
         </div>

--- a/packages/js/examples/heroku/index.js
+++ b/packages/js/examples/heroku/index.js
@@ -13,6 +13,8 @@ const inCallElements = [
   controlLayout,
   hideVMutedBtn,
   showVMutedBtn,
+  hideScreenShareBtn,
+  showScreenShareBtn,
 ]
 
 async function loadLayouts(currentLayoutId) {
@@ -155,6 +157,14 @@ window.ready = (callback) => {
       }
     })
   }
+}
+
+let screenShareObj
+window.startScreenShare = async () => {
+  screenShareObj = await roomObj.createScreenShareObject()
+}
+window.stopScreenShare = () => {
+  screenShareObj.hangup()
 }
 
 window.muteAll = () => {

--- a/packages/js/src/Client.ts
+++ b/packages/js/src/Client.ts
@@ -27,7 +27,7 @@ export class Client extends BaseClient {
           componentListeners: {
             state: 'onStateChange',
             remoteSDP: 'onRemoteSDP',
-            roomId: 'onRoomId',
+            roomId: 'onRoomSubscribed',
             errors: 'onError',
             responses: 'onSuccess',
           },

--- a/packages/js/src/createClient.ts
+++ b/packages/js/src/createClient.ts
@@ -66,6 +66,7 @@ export const createClient = async (userOptions: UserOptions) => {
     componentListeners: {
       errors: 'onError',
       responses: 'onSuccess',
+      id: 'onClientSubscribed',
     },
   })(baseUserOptions)
   if (baseUserOptions.autoConnect) {

--- a/packages/node/src/Client.ts
+++ b/packages/node/src/Client.ts
@@ -3,10 +3,8 @@ import {
   ExecuteParams,
   logger,
   SessionState,
+  GlobalVideoEvents,
 } from '@signalwire/core'
-
-// TODO: reuse types from @signalwire/core
-type GlobalVideoEvents = 'room.started' | 'room.ended'
 
 interface Consumer {
   subscribe: (event: GlobalVideoEvents, handler: any) => void

--- a/packages/node/src/createWebSocketClient.ts
+++ b/packages/node/src/createWebSocketClient.ts
@@ -25,6 +25,7 @@ export const createWebSocketClient = async (userOptions: UserOptions) => {
     componentListeners: {
       errors: 'onError',
       responses: 'onSuccess',
+      id: 'onClientSubscribed',
     },
     sessionListeners: {
       authStatus: 'onAuth',

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -262,7 +262,11 @@ export class BaseConnection extends BaseComponent {
     this._attachListeners(component.roomSessionId)
   }
 
-  /** @internal */
+  /**
+   * TODO: This is just needed for `screenShareObj`'s. We're using
+   * this to namespace that object with `nodeId`
+   * @internal
+   **/
   public onNodeId(component: any) {
     this._attachListeners(component.nodeId)
   }

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -34,6 +34,18 @@ const ROOM_EVENTS = [
   'layout.changed',
 ]
 
+/**
+ * Events to be subscribing for screen sharing during
+ * `VertoMethod.Invite`
+ */
+const SCREENSHARE_ROOM_EVENTS = [
+  /**
+   * This is not a real event, it's only being used for debugging
+   * purposes
+   */
+  'room.screenshare',
+]
+
 const DEFAULT_CALL_OPTIONS: ConnectionOptions = {
   destinationNumber: 'room',
   remoteCallerName: 'Outbound Call',
@@ -208,7 +220,7 @@ export class BaseConnection extends BaseComponent {
     }
     if (vertoMessage.method === VertoMethod.Invite) {
       if (this.options.screenShare) {
-        params.subscribe = ['room.screenshare']
+        params.subscribe = SCREENSHARE_ROOM_EVENTS
       } else {
         params.subscribe = ROOM_EVENTS
       }
@@ -242,17 +254,17 @@ export class BaseConnection extends BaseComponent {
   }
 
   /** @internal */
-  public onRoomId(component: any) {
-    logger.debug('onRoomId', component)
+  public onRoomSubscribed(component: any) {
+    logger.debug('onRoomSubscribed', component)
     this._roomId = component.roomId
     this._roomSessionId = component.roomSessionId
     this._memberId = component.memberId
-    this.onConnect(component.roomSessionId)
+    this._attachListeners(component.roomSessionId)
   }
 
   /** @internal */
   public onNodeId(component: any) {
-    this.onConnect(component.nodeId)
+    this._attachListeners(component.nodeId)
   }
 
   // async updateDevices(constraints: MediaStreamConstraints): Promise<void> {

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -247,6 +247,12 @@ export class BaseConnection extends BaseComponent {
     this._roomId = component.roomId
     this._roomSessionId = component.roomSessionId
     this._memberId = component.memberId
+    this.onConnect(component.roomSessionId)
+  }
+
+  /** @internal */
+  public onNodeId(component: any) {
+    this.onConnect(component.nodeId)
   }
 
   // async updateDevices(constraints: MediaStreamConstraints): Promise<void> {

--- a/packages/webrtc/src/Room.ts
+++ b/packages/webrtc/src/Room.ts
@@ -30,6 +30,7 @@ export class Room extends BaseConnection {
       componentListeners: {
         state: 'onStateChange',
         remoteSDP: 'onRemoteSDP',
+        // TODO: find another way to namespace `screenShareObj`s
         nodeId: 'onNodeId',
         errors: 'onError',
         responses: 'onSuccess',

--- a/packages/webrtc/src/Room.ts
+++ b/packages/webrtc/src/Room.ts
@@ -1,4 +1,4 @@
-import { logger, connect, getEventEmitter } from '@signalwire/core'
+import { logger, connect } from '@signalwire/core'
 import { getDisplayMedia } from './utils/webrtcHelpers'
 import { RoomObject, CreateScreenShareObjectOptions } from './utils/interfaces'
 import { BaseConnection, BaseConnectionOptions } from './BaseConnection'
@@ -16,16 +16,12 @@ export class Room extends BaseConnection {
   async createScreenShareObject(opts: CreateScreenShareObjectOptions = {}) {
     const { autoJoin = true, audio = false, video = true } = opts
     const displayStream: MediaStream = await getDisplayMedia({ audio, video })
-
-    // FIXME: Remove it when "scoped" emitters are in
-    const fakeEmitter = getEventEmitter({ token: '' })
     const options: BaseConnectionOptions = {
       ...this.options,
       screenShare: true,
       recoverCall: false,
       skipLiveArray: true,
       localStream: displayStream,
-      emitter: fakeEmitter,
     }
 
     const screenShare: RoomObject = connect({
@@ -34,7 +30,7 @@ export class Room extends BaseConnection {
       componentListeners: {
         state: 'onStateChange',
         remoteSDP: 'onRemoteSDP',
-        roomId: 'onRoomId',
+        nodeId: 'onNodeId',
         errors: 'onError',
         responses: 'onSuccess',
       },


### PR DESCRIPTION
The code in this changeset includes the ability to namespace each event emitter with a namespace. That namespace is determined by the `room_session_id` (as recommended on [this ticket](https://github.com/signalwire/cloud-support/issues/1011)).

Biggest change was converting the emitter from being sync to async since we won't have access to the `room_session_id` until a successful connection.

Closes https://github.com/signalwire/cloud-support/issues/994