### PR TITLE
Add util for creating slices

### DIFF
--- a/.changeset/neat-weeks-live.md
+++ b/.changeset/neat-weeks-live.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': patch
+---
+
+Internal refactor for creating destroyable slices without repetition.

--- a/packages/core/src/redux/features/component/componentSlice.ts
+++ b/packages/core/src/redux/features/component/componentSlice.ts
@@ -1,7 +1,7 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { PayloadAction } from '@reduxjs/toolkit'
 import { JSONRPCResponse } from '../../../utils/interfaces'
 import { ComponentState, ReduxComponent } from '../../interfaces'
-import { destroyAction } from '../../actions'
+import { createDestroyableSlice } from '../../utils/createDestroyableSlice'
 
 export const initialComponentState: Readonly<ComponentState> = {
   byId: {},
@@ -21,7 +21,7 @@ type FailureParams = {
   action: any
 }
 
-const componentSlice = createSlice({
+const componentSlice = createDestroyableSlice({
   name: 'components',
   initialState: initialComponentState,
   reducers: {
@@ -55,11 +55,6 @@ const componentSlice = createSlice({
         }
       }
     },
-  },
-  extraReducers: (builder) => {
-    builder.addCase(destroyAction.type, () => {
-      return initialComponentState
-    })
   },
 })
 

--- a/packages/core/src/redux/features/session/sessionSlice.ts
+++ b/packages/core/src/redux/features/session/sessionSlice.ts
@@ -1,10 +1,11 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { PayloadAction } from '@reduxjs/toolkit'
 import { SessionState } from '../../interfaces'
 import {
   IBladeConnectResult,
   SessionAuthError,
 } from '../../../utils/interfaces'
-import { destroyAction, authError } from '../../actions'
+import { authError } from '../../actions'
+import { createDestroyableSlice } from '../../utils/createDestroyableSlice'
 
 export const initialSessionState: Readonly<SessionState> = {
   protocol: '',
@@ -13,7 +14,7 @@ export const initialSessionState: Readonly<SessionState> = {
   authError: undefined,
 }
 
-const sessionSlice = createSlice({
+const sessionSlice = createDestroyableSlice({
   name: 'session',
   initialState: initialSessionState,
   reducers: {
@@ -24,9 +25,6 @@ const sessionSlice = createSlice({
     },
   },
   extraReducers: (builder) => {
-    builder.addCase(destroyAction.type, () => {
-      return initialSessionState
-    })
     builder.addCase(
       authError.type,
       (state, { payload }: PayloadAction<{ error: SessionAuthError }>) => {

--- a/packages/core/src/redux/utils/createDestroyableSlice.test.ts
+++ b/packages/core/src/redux/utils/createDestroyableSlice.test.ts
@@ -1,0 +1,41 @@
+import { createDestroyableSlice } from './createDestroyableSlice'
+import { destroyAction } from '../actions'
+
+describe('createDestroyableSlice', () => {
+  it('should set the state back to its `initialState` when the `detroyAction` is dispatched', () => {
+    const initialState = { status: true, id: '1234-6789-1011' }
+    const slice = createDestroyableSlice({
+      name: 'destroyable-slice',
+      initialState,
+      reducers: {},
+      extraReducers: () => {},
+    })
+
+    expect(
+      slice.reducer({ status: false, id: '2345-6789-1122' }, destroyAction())
+    ).toStrictEqual(initialState)
+  })
+
+  it('should allow to pass extra reducers', () => {
+    const initialState = { status: true, id: '1234-6789-1011' }
+    const caseReducerState1 = { status: false, id: '2345-6789-1122' }
+    const caseReducerState2 = { status: true, id: '2345-6789-1122' }
+
+    const slice = createDestroyableSlice({
+      name: 'destroyable-slice',
+      initialState,
+      reducers: {},
+      extraReducers: (builder) => {
+        builder.addCase('a-new-event-type-1', () => caseReducerState1)
+        builder.addCase('a-new-event-type-2', () => caseReducerState2)
+      },
+    })
+
+    expect(
+      slice.reducer(initialState, { type: 'a-new-event-type-1' })
+    ).toStrictEqual(caseReducerState1)
+    expect(
+      slice.reducer(initialState, { type: 'a-new-event-type-2' })
+    ).toStrictEqual(caseReducerState2)
+  })
+})

--- a/packages/core/src/redux/utils/createDestroyableSlice.ts
+++ b/packages/core/src/redux/utils/createDestroyableSlice.ts
@@ -1,0 +1,37 @@
+import {
+  SliceCaseReducers,
+  ValidateSliceCaseReducers,
+  createSlice,
+  ActionReducerMapBuilder,
+} from '@reduxjs/toolkit'
+import { destroyAction } from '../actions'
+
+export const createDestroyableSlice = <
+  T,
+  Reducers extends SliceCaseReducers<T>
+>({
+  name = '',
+  initialState,
+  reducers,
+  extraReducers,
+}: {
+  name: string
+  initialState: T
+  reducers: ValidateSliceCaseReducers<T, Reducers>
+  extraReducers?: (builder: ActionReducerMapBuilder<T>) => void
+}) => {
+  return createSlice({
+    name,
+    initialState,
+    reducers,
+    extraReducers: (builder) => {
+      builder.addCase(destroyAction.type, () => {
+        return initialState
+      })
+
+      if (typeof extraReducers === 'function') {
+        extraReducers(builder)
+      }
+    },
+  })
+}


### PR DESCRIPTION
The code in this changeset includes a new util for creating slices that automatically handle the `destroyAction` dispatched at cleanup time.

Fixes: #64