### PR TITLE
Fix videoOverlay and vmute bug

### DIFF
--- a/.changeset/thirty-stingrays-develop.md
+++ b/.changeset/thirty-stingrays-develop.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': patch
+---
+
+Fix bug with the localVideo overlay rendering

--- a/packages/js/src/Client.ts
+++ b/packages/js/src/Client.ts
@@ -49,7 +49,7 @@ export class Client extends BaseClient {
             if (room.localVideoTrack) {
               layoutChangedHandler({
                 layout: params.layout,
-                localVideoTrack: room.localVideoTrack,
+                localStream: room.localStream,
                 myMemberId: room.memberId,
               })
             }

--- a/packages/js/src/Client.ts
+++ b/packages/js/src/Client.ts
@@ -46,7 +46,7 @@ export class Client extends BaseClient {
           } = videoElementFactory({ rootElementId, applyLocalVideoOverlay })
 
           room.on('layout.changed', (params: any) => {
-            if (room.localVideoTrack) {
+            if (room.peer.hasVideoSender && room.localStream) {
               layoutChangedHandler({
                 layout: params.layout,
                 localStream: room.localStream,

--- a/packages/js/src/utils/videoElementFactory.ts
+++ b/packages/js/src/utils/videoElementFactory.ts
@@ -3,14 +3,20 @@ import { logger, RoomLayout, RoomLayoutLayer } from '@signalwire/core'
 type LayoutChangedHandlerParams = {
   layout: RoomLayout
   myMemberId: string
-  localVideoTrack: MediaStreamTrack
+  localStream?: MediaStream
 }
 
-const buildVideoElementByTrack = (videoTrack: MediaStreamTrack) => {
+const buildVideo = () => {
   const video = document.createElement('video')
   video.muted = true
   video.autoplay = true
   video.playsInline = true
+
+  return video
+}
+
+const buildVideoElementByTrack = (videoTrack: MediaStreamTrack) => {
+  const video = buildVideo()
   video.srcObject = new MediaStream([videoTrack])
 
   videoTrack.addEventListener('ended', () => {
@@ -143,7 +149,7 @@ export const videoElementFactory = ({
   const layoutChangedHandler = async ({
     layout,
     myMemberId,
-    localVideoTrack,
+    localStream,
   }: LayoutChangedHandlerParams) => {
     try {
       const { layers = [] } = layout
@@ -158,7 +164,8 @@ export const videoElementFactory = ({
         const myLayer = await _buildLayer(layer)
         myLayer.id = myMemberId
 
-        const localVideo = buildVideoElementByTrack(localVideoTrack)
+        const localVideo = buildVideo()
+        localVideo.srcObject = localStream as MediaStream
         localVideo.style.width = '100%'
         localVideo.style.height = '100%'
 

--- a/packages/js/src/utils/videoElementFactory.ts
+++ b/packages/js/src/utils/videoElementFactory.ts
@@ -3,7 +3,7 @@ import { logger, RoomLayout, RoomLayoutLayer } from '@signalwire/core'
 type LayoutChangedHandlerParams = {
   layout: RoomLayout
   myMemberId: string
-  localStream?: MediaStream
+  localStream: MediaStream
 }
 
 const buildVideo = () => {
@@ -63,7 +63,6 @@ export const videoElementFactory = ({
         videoEl = buildVideoElementByTrack(event.track)
         videoEl.style.width = '100%'
         videoEl.style.height = '100%'
-        // videoEl.style.border = '2px solid yellow'
 
         if (!applyLocalVideoOverlay) {
           rootElement.appendChild(videoEl)
@@ -72,7 +71,6 @@ export const videoElementFactory = ({
 
         const mcuWrapper = document.createElement('div')
         mcuWrapper.style.position = 'absolute'
-        // inset: 0
         mcuWrapper.style.top = '0'
         mcuWrapper.style.left = '0'
         mcuWrapper.style.right = '0'
@@ -81,7 +79,6 @@ export const videoElementFactory = ({
 
         const paddingWrapper = document.createElement('div')
         paddingWrapper.style.paddingBottom = '56.25%'
-        // paddingWrapper.style.border = '2px solid green'
         paddingWrapper.appendChild(mcuWrapper)
 
         const layersWrapper = document.createElement('div')
@@ -93,7 +90,6 @@ export const videoElementFactory = ({
         relativeWrapper.style.width = '100%'
         relativeWrapper.style.height = '100%'
         relativeWrapper.style.margin = '0 auto'
-        // relativeWrapper.style.border = '2px solid red'
         relativeWrapper.appendChild(paddingWrapper)
 
         rootElement.appendChild(relativeWrapper)
@@ -165,7 +161,7 @@ export const videoElementFactory = ({
         myLayer.id = myMemberId
 
         const localVideo = buildVideo()
-        localVideo.srcObject = localStream as MediaStream
+        localVideo.srcObject = localStream
         localVideo.style.width = '100%'
         localVideo.style.height = '100%'
 

--- a/packages/js/src/utils/videoElementFactory.ts
+++ b/packages/js/src/utils/videoElementFactory.ts
@@ -1,9 +1,9 @@
 import { logger, RoomLayout, RoomLayoutLayer } from '@signalwire/core'
 
 type LayoutChangedHandlerParams = {
-  layout: RoomLayout,
-  myMemberId: string,
-  localVideoTrack: MediaStreamTrack,
+  layout: RoomLayout
+  myMemberId: string
+  localVideoTrack: MediaStreamTrack
 }
 
 const buildVideoElementByTrack = (videoTrack: MediaStreamTrack) => {
@@ -15,11 +15,7 @@ const buildVideoElementByTrack = (videoTrack: MediaStreamTrack) => {
   const mediaStream = new MediaStream([videoTrack])
   video.srcObject = mediaStream
 
-  const onCanPlay = () => logger.debug('Video can play')
-  const onPlay = () => logger.debug('Video is playing')
   videoTrack.addEventListener('ended', () => {
-    video.removeEventListener('play', onPlay)
-    video.removeEventListener('canplay', onCanPlay)
     video.srcObject = null
     video.remove()
   })
@@ -35,13 +31,7 @@ const buildAudioElementByTrack = (audioTrack: MediaStreamTrack) => {
   const mediaStream = new MediaStream([audioTrack])
   audio.srcObject = mediaStream
 
-  const onCanPlay = () => logger.debug('Audio can play!')
-  const onPlay = () => logger.debug('Audio is playing')
-  audio.addEventListener('play', onPlay)
-  audio.addEventListener('canplay', onCanPlay)
   audioTrack.addEventListener('ended', () => {
-    audio.removeEventListener('play', onPlay)
-    audio.removeEventListener('canplay', onCanPlay)
     audio.srcObject = null
     audio.remove()
   })

--- a/packages/js/src/utils/videoElementFactory.ts
+++ b/packages/js/src/utils/videoElementFactory.ts
@@ -11,9 +11,7 @@ const buildVideoElementByTrack = (videoTrack: MediaStreamTrack) => {
   video.muted = true
   video.autoplay = true
   video.playsInline = true
-
-  const mediaStream = new MediaStream([videoTrack])
-  video.srcObject = mediaStream
+  video.srcObject = new MediaStream([videoTrack])
 
   videoTrack.addEventListener('ended', () => {
     video.srcObject = null
@@ -27,9 +25,7 @@ const buildAudioElementByTrack = (audioTrack: MediaStreamTrack) => {
   audio.autoplay = true
   // @ts-ignore
   audio.playsinline = true
-
-  const mediaStream = new MediaStream([audioTrack])
-  audio.srcObject = mediaStream
+  audio.srcObject = new MediaStream([audioTrack])
 
   audioTrack.addEventListener('ended', () => {
     audio.srcObject = null

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -386,7 +386,6 @@ export class BaseConnection extends BaseComponent {
               'updateConstraints FOUND - replaceTrack on it and on localStream'
             )
             await transceiver.sender.replaceTrack(newTrack)
-            this.options.localStream.addTrack(newTrack)
             logger.debug('updateConstraints replaceTrack SUCCESS')
             this.options.localStream.getTracks().forEach((track) => {
               if (track.kind === newTrack.kind && track.id !== newTrack.id) {
@@ -397,6 +396,8 @@ export class BaseConnection extends BaseComponent {
                 this.options.localStream?.removeTrack(track)
               }
             })
+
+            this.options.localStream.addTrack(newTrack)
           } else {
             logger.debug(
               'updateConstraints NOT FOUND - addTrack and start dancing!'


### PR DESCRIPTION
In this PR i've used `localStream` instead of the current video track to survive to the video-muted state where the sender's track is destroyed.

Closes https://github.com/signalwire/cloud-support/issues/998