### PR TITLE
Remove event listeners by namespace

### DIFF
--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -142,14 +142,11 @@ export class BaseComponent implements Emitter {
           // TODO: TBD
         }
       })
+    } else {
+      throw new Error(
+        'Component `removeAllListeners` invoked without "event" or "namespace" set.'
+      )
     }
-    // // @ts-ignore
-    // logger.info('>> removeAllListeners', event, this._getNamespacedEvent(event))
-    // // @ts-ignore
-    // logger.info('>> removeAllListeners all?', this.emitter.eventNames())
-    // return this.emitter.removeAllListeners(
-    //   event ? this._getNamespacedEvent(event) : event
-    // )
 
     return this.emitter as EventEmitter<string | symbol, any>
   }

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -127,9 +127,35 @@ export class BaseComponent implements Emitter {
     }
 
     const [event] = params
-    return this.emitter.removeAllListeners(
-      event ? this._getNamespacedEvent(event) : event
-    )
+    if (event) {
+      return this.emitter.removeAllListeners(this._getNamespacedEvent(event))
+    }
+
+    if (this._eventsNamespace !== undefined) {
+      this.eventNames().forEach((event) => {
+        if (
+          typeof event === 'string' &&
+          event.startsWith(this._eventsNamespace!)
+        ) {
+          this.emitter.removeAllListeners(event)
+        } else if (typeof event === 'symbol') {
+          // TODO: TBD
+        }
+      })
+    }
+    // // @ts-ignore
+    // logger.info('>> removeAllListeners', event, this._getNamespacedEvent(event))
+    // // @ts-ignore
+    // logger.info('>> removeAllListeners all?', this.emitter.eventNames())
+    // return this.emitter.removeAllListeners(
+    //   event ? this._getNamespacedEvent(event) : event
+    // )
+
+    return this.emitter as EventEmitter<string | symbol, any>
+  }
+
+  eventNames() {
+    return this.emitter.eventNames()
   }
 
   emit(event: string | symbol, ...args: any[]) {

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -1,4 +1,4 @@
-import { uuid, logger } from './utils'
+import { uuid, logger, getGlobalEvents } from './utils'
 import { executeAction } from './redux'
 import {
   ExecuteParams,
@@ -7,7 +7,6 @@ import {
 } from './utils/interfaces'
 import { EventEmitter, getNamespacedEvent } from './utils/EventEmitter'
 import { SDKState } from './redux/interfaces'
-import { GLOBAL_VIDEO_EVENTS } from './utils/constants'
 
 type EventRegisterHandlers =
   | {
@@ -146,9 +145,8 @@ export class BaseComponent implements Emitter {
         }
       })
     } else {
-      // TODO: Handle all the global events (not only `VIDEO`)
       logger.debug('Removing global events only.')
-      GLOBAL_VIDEO_EVENTS.forEach((event) => {
+      getGlobalEvents().forEach((event) => {
         this.emitter.removeAllListeners(event)
       })
     }

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -7,6 +7,7 @@ import {
 } from './utils/interfaces'
 import { EventEmitter, getNamespacedEvent } from './utils/EventEmitter'
 import { SDKState } from './redux/interfaces'
+import { GLOBAL_VIDEO_EVENTS } from './utils/constants'
 
 type EventRegisterHandlers =
   | {
@@ -139,13 +140,17 @@ export class BaseComponent implements Emitter {
         ) {
           this.emitter.removeAllListeners(event)
         } else if (typeof event === 'symbol') {
-          // TODO: TBD
+          logger.warn(
+            'Remove events registered using `symbol` is not supported.'
+          )
         }
       })
     } else {
-      throw new Error(
-        'Component `removeAllListeners` invoked without "event" or "namespace" set.'
-      )
+      // TODO: Handle all the global events (not only `VIDEO`)
+      logger.debug('Removing global events only.')
+      GLOBAL_VIDEO_EVENTS.forEach((event) => {
+        this.emitter.removeAllListeners(event)
+      })
     }
 
     return this.emitter as EventEmitter<string | symbol, any>

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -52,3 +52,15 @@ export const isGlobalEvent = (event: RoomEventNames) => {
   // @ts-ignore
   return GLOBAL_VIDEO_EVENTS.includes(event)
 }
+
+export const getGlobalEvents = (kind: 'all' | 'video' = 'all') => {
+  switch (kind) {
+    case 'video':
+      return GLOBAL_VIDEO_EVENTS
+    default:
+      // prettier-ignore
+      return [
+        ...GLOBAL_VIDEO_EVENTS,
+      ]
+  }
+}

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -8,7 +8,7 @@ import { GLOBAL_VIDEO_EVENTS } from './constants'
  */
 export type Emitter = Pick<
   EventEmitter,
-  'on' | 'off' | 'once' | 'emit' | 'removeAllListeners'
+  'on' | 'off' | 'once' | 'emit' | 'removeAllListeners' | 'eventNames'
 >
 
 type JSONRPCParams = {


### PR DESCRIPTION
The current BaseComponent `removeAllListeners()` removes all the handlers if the `event` is undefined.
This is true when invoked by `destroy()`

```ts
  destroy() {
    this._destroyer?.()
    this.removeAllListeners()
  }
```


Closes https://github.com/signalwire/cloud-support/issues/1037