### PR TITLE
Rename secondSource methods

### DIFF
--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -211,7 +211,7 @@ export interface RoomLayoutLayer {
   member_id: string
 }
 
-type RoomMemberType = 'member' | 'screen' | 'additional_source'
+type RoomMemberType = 'member' | 'screen' | 'device'
 interface RoomMemberCommon {
   id: string
 }

--- a/packages/js/src/Room.ts
+++ b/packages/js/src/Room.ts
@@ -119,7 +119,7 @@ export class Room extends BaseConnection {
       remoteStream: undefined,
       audio,
       video,
-      secondSource: true,
+      additionalDevice: true,
       recoverCall: false,
     }
 

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -23,8 +23,15 @@ export type CreateScreenShareObjectOptions = {
   video?: MediaStreamConstraints['video']
 }
 
-export type CreateSecondSourceObjectOptions = {
+export type AddDeviceOptions = {
   autoJoin?: boolean
   audio?: MediaStreamConstraints['audio']
   video?: MediaStreamConstraints['video']
+}
+
+export type AddCameraOptions = MediaTrackConstraints & {
+  autoJoin?: boolean
+}
+export type AddMicrophoneOptions = MediaTrackConstraints & {
+  autoJoin?: boolean
 }

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -51,12 +51,12 @@ const SCREENSHARE_ROOM_EVENTS = [
  * Events to be subscribing for screen sharing during
  * `VertoMethod.Invite`
  */
-const SECONDSOURCE_ROOM_EVENTS = [
+const DEVICE_ROOM_EVENTS = [
   /**
    * This is not a real event, it's only being used for debugging
    * purposes
    */
-  'room.secondsource',
+  'room.additionaldevice',
 ]
 
 const DEFAULT_CALL_OPTIONS: ConnectionOptions = {
@@ -70,7 +70,7 @@ const DEFAULT_CALL_OPTIONS: ConnectionOptions = {
   useStereo: false,
   attach: false,
   screenShare: false,
-  secondSource: false,
+  additionalDevice: false,
   userVariables: {},
   requestTimeout: 10 * 1000,
   autoApplyMediaParams: true,
@@ -164,7 +164,7 @@ export class BaseConnection extends BaseComponent {
       remoteCallerNumber,
       userVariables,
       screenShare,
-      secondSource,
+      additionalDevice,
     } = this.options
     return {
       sessid: this.options.sessionid,
@@ -178,7 +178,7 @@ export class BaseConnection extends BaseComponent {
         remoteCallerNumber,
         userVariables,
         screenShare,
-        secondSource,
+        additionalDevice,
       },
     }
   }
@@ -236,8 +236,8 @@ export class BaseConnection extends BaseComponent {
     if (vertoMessage.method === VertoMethod.Invite) {
       if (this.options.screenShare) {
         params.subscribe = SCREENSHARE_ROOM_EVENTS
-      } else if (this.options.secondSource) {
-        params.subscribe = SECONDSOURCE_ROOM_EVENTS
+      } else if (this.options.additionalDevice) {
+        params.subscribe = DEVICE_ROOM_EVENTS
       } else {
         params.subscribe = ROOM_EVENTS
       }

--- a/packages/webrtc/src/RTCPeer.ts
+++ b/packages/webrtc/src/RTCPeer.ts
@@ -223,9 +223,9 @@ export default class RTCPeer {
     this._negotiating = true
     try {
       /**
-       * secondSource and screenShare are `sendonly`
+       * additionalDevice and screenShare are `sendonly`
        */
-      if (this.options.secondSource || this.options.screenShare) {
+      if (this.options.additionalDevice || this.options.screenShare) {
         this.instance.getTransceivers().forEach((tr) => {
           tr.direction = 'sendonly'
         })

--- a/packages/webrtc/src/utils/interfaces.ts
+++ b/packages/webrtc/src/utils/interfaces.ts
@@ -24,7 +24,7 @@ export interface ConnectionOptions {
   speakerId?: string
   userVariables?: { [key: string]: any }
   screenShare?: boolean
-  secondSource?: boolean
+  additionalDevice?: boolean
   recoverCall?: boolean
   onNotification?: Function
   googleMaxBitrate?: number


### PR DESCRIPTION
In this PR i just renamed the methods using `addDevice` (and helper methods like addCamera/addMicrophone). In another PR i'll split the objects from RoomObject into RoomDevice as discussed.