### PR TITLE
Set memberId and roomSessionId on RoomDevice and RoomScreenShare

### DIFF
--- a/packages/js/src/Room.ts
+++ b/packages/js/src/Room.ts
@@ -60,6 +60,15 @@ class Room extends BaseConnection implements BaseRoomInterface {
     })(options)
 
     /**
+     *  FIXME: Remove this workaround when
+     * we get room.subscribed for screenShare
+     * and device sessions.
+     */
+    screenShare._memberId = screenShare.id
+    screenShare._roomId = this.roomId
+    screenShare._roomSessionId = this.roomSessionId
+
+    /**
      * Hangup if the user stop the screenShare from the
      * native browser button or if the videoTrack ends.
      */
@@ -142,6 +151,15 @@ class Room extends BaseConnection implements BaseRoomInterface {
         responses: 'onSuccess',
       },
     })(options)
+
+    /**
+     *  FIXME: Remove this workaround when
+     * we get room.subscribed for screenShare
+     * and device sessions.
+     */
+    roomDevice._memberId = roomDevice.id
+    roomDevice._roomId = this.roomId
+    roomDevice._roomSessionId = this.roomSessionId
 
     roomDevice.on('destroy', () => {
       this._deviceList.delete(roomDevice)

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -91,10 +91,18 @@ export class BaseConnection
   private state: BaseConnectionState = 'new'
   private prevState: BaseConnectionState = 'new'
 
-  // @ts-ignore
-  private _roomId: string
-  private _roomSessionId: string
-  private _memberId: string
+  /**
+   *  FIXME: Remove this workaround when
+   * we get room.subscribed for screenShare
+   * and device sessions.
+   */
+
+  /** @internal */
+  public _roomId: string
+  /** @internal */
+  public _roomSessionId: string
+  /** @internal */
+  public _memberId: string
 
   constructor(options: BaseConnectionOptions) {
     super(options)


### PR DESCRIPTION
This is a temporary workaround to set memberId and roomSessionId on RoomDevice and RoomScreenShare from the parent. 

Waiting for https://github.com/signalwire/cloud-support/issues/1065 