### PR TITLE
Check result.code parsing JSONRPC responses

### DIFF
--- a/packages/core/src/utils/parseRPCResponse.test.ts
+++ b/packages/core/src/utils/parseRPCResponse.test.ts
@@ -43,6 +43,16 @@ describe('parseRPCResponse', () => {
         result: { code: '200', message: 'Playing', call_id: 'call-id' },
       })
     })
+
+    it('should handle the error code within result', () => {
+      const response = JSON.parse(
+        '{"jsonrpc":"2.0","id":"uuid","result":{"code":"-32001","message":"Permission Denied."}}'
+      )
+      expect(parseRPCResponse({ request, response })).toEqual({
+        error: { code: '-32001', message: 'Permission Denied.' },
+      })
+    })
+
     it('should handle the error', () => {
       const response = JSON.parse(
         '{"jsonrpc":"2.0","id":"uuid","error":{"code":-32601,"message":"Error Message"}}'

--- a/packages/core/src/utils/parseRPCResponse.ts
+++ b/packages/core/src/utils/parseRPCResponse.ts
@@ -40,15 +40,15 @@ const parseResponse = (
     return { error }
   }
   const { code, node_id, result: vertoResult = null } = result
+  if (code && code !== '200') {
+    return { error: result }
+  }
   if (vertoResult === null) {
     if (nodeId) {
       // Attach node_id to the vertoResult
       result.node_id = nodeId
     }
     return { result }
-  }
-  if (code && code !== '200') {
-    return { error: result }
   }
   if (vertoResult) {
     return parseResponse(vertoResult, node_id)


### PR DESCRIPTION
The server can respond with the payload below that is not JSONRPC-complaint because `result` should be `error`. But for server-side internal reasons the SDK have to check the `result.code` and if not `"200"` (as string) trait the response as an error. 

```json
{
  "jsonrpc": "2.0",
  "id": "11a99fda-6c3e-48d3-912c-5d09bf2ae8fe",
  "result": {
    "code": "-32001",
    "message": "Permission Denied."
  }
}
```