### PR TITLE
Remove workaround for RoomDevice/RoomScreenShare objects

### DIFF
--- a/packages/core/src/redux/features/session/sessionSaga.ts
+++ b/packages/core/src/redux/features/session/sessionSaga.ts
@@ -19,6 +19,7 @@ import { componentActions } from '../'
 import { RPCExecute } from '../../../RPCMessages'
 import { logger } from '../../../utils'
 import { getAuthStatus } from '../session/sessionSelectors'
+import { getComponent } from '../component/componentSelectors'
 import { SessionAuthStatus } from '../../../utils/interfaces'
 
 type SessionSagaParams = {
@@ -189,7 +190,7 @@ export function* sessionChannelWatcher({
     }
   }
 
-  function* videoAPIWorker(params: VideoAPIEventParams) {
+  function* videoAPIWorker(params: VideoAPIEventParams): SagaIterator {
     switch (params.event_type) {
       case 'video.room.subscribed': {
         yield put(
@@ -217,6 +218,29 @@ export function* sessionChannelWatcher({
             type,
             payload: params.params,
           })
+        }
+        break
+      }
+      case 'video.member.joined': {
+        /**
+         * On member.joined with a parent_id, check if we are the
+         * owner of the object comparing parent_id in the state.
+         * If so update the state with the room values to update the
+         * object (= trigger `onRoomSubscribed`).
+         */
+        const { member } = params.params
+        if (member?.parent_id) {
+          const parent = yield select(getComponent, member.parent_id)
+          if (parent) {
+            yield put(
+              componentActions.upsert({
+                id: member.id,
+                roomId: params.params.room_id,
+                roomSessionId: params.params.room_session_id,
+                memberId: member.id,
+              })
+            )
+          }
         }
         break
       }

--- a/packages/core/src/types/video.ts
+++ b/packages/core/src/types/video.ts
@@ -146,6 +146,8 @@ interface RoomSubscribedEvent extends SwEvent {
 interface MemberUpdatedEvent extends SwEvent {
   event_type: `video.${MemberUpdatedEventName}`
   params: {
+    room_session_id: string
+    room_id: string
     member: {
       updated: Array<keyof RoomMemberProperties>
     } & RoomMemberCommon &
@@ -156,6 +158,8 @@ interface MemberUpdatedEvent extends SwEvent {
 interface MemberJoinedEvent extends SwEvent {
   event_type: `video.${MemberJoinedEventName}`
   params: {
+    room_session_id: string
+    room_id: string
     member: Member
   }
 }
@@ -163,6 +167,8 @@ interface MemberJoinedEvent extends SwEvent {
 interface MemberLeftEvent extends SwEvent {
   event_type: `video.${MemberLeftEventName}`
   params: {
+    room_session_id: string
+    room_id: string
     member: Member
   }
 }
@@ -170,6 +176,8 @@ interface MemberLeftEvent extends SwEvent {
 interface MemberTalkingEvent extends SwEvent {
   event_type: `video.${MemberTalkingEventName}`
   params: {
+    room_session_id: string
+    room_id: string
     member: RoomMemberCommon & {
       talking: boolean
     }

--- a/packages/js/src/Room.ts
+++ b/packages/js/src/Room.ts
@@ -52,21 +52,11 @@ class Room extends BaseConnection implements BaseRoomInterface {
       componentListeners: {
         state: 'onStateChange',
         remoteSDP: 'onRemoteSDP',
-        // TODO: find another way to namespace `screenShareObj`s
-        nodeId: 'onNodeId',
+        roomId: 'onRoomSubscribed',
         errors: 'onError',
         responses: 'onSuccess',
       },
     })(options)
-
-    /**
-     *  FIXME: Remove this workaround when
-     * we get room.subscribed for screenShare
-     * and device sessions.
-     */
-    screenShare._memberId = screenShare.id
-    screenShare._roomId = this.roomId
-    screenShare._roomSessionId = this.roomSessionId
 
     /**
      * Hangup if the user stop the screenShare from the
@@ -145,21 +135,11 @@ class Room extends BaseConnection implements BaseRoomInterface {
       componentListeners: {
         state: 'onStateChange',
         remoteSDP: 'onRemoteSDP',
-        // TODO: find another way to namespace `roomDeviceObj`s
-        nodeId: 'onNodeId',
+        roomId: 'onRoomSubscribed',
         errors: 'onError',
         responses: 'onSuccess',
       },
     })(options)
-
-    /**
-     *  FIXME: Remove this workaround when
-     * we get room.subscribed for screenShare
-     * and device sessions.
-     */
-    roomDevice._memberId = roomDevice.id
-    roomDevice._roomId = this.roomId
-    roomDevice._roomSessionId = this.roomSessionId
 
     roomDevice.on('destroy', () => {
       this._deviceList.delete(roomDevice)

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -271,16 +271,16 @@ export class BaseConnection
     this._roomId = component.roomId
     this._roomSessionId = component.roomSessionId
     this._memberId = component.memberId
-    this._attachListeners(component.roomSessionId)
-  }
 
-  /**
-   * TODO: This is just needed for `screenShareObj`'s. We're using
-   * this to namespace that object with `nodeId`
-   * @internal
-   **/
-  public onNodeId(component: any) {
-    this._attachListeners(component.nodeId)
+    /**
+     * For screenShare/additionalDevice we're using
+     * the `memberId` to namespace the object.
+     **/
+    if (this.options.additionalDevice || this.options.screenShare) {
+      this._attachListeners(component.memberId)
+    } else {
+      this._attachListeners(component.roomSessionId)
+    }
   }
 
   updateCamera(constraints: MediaTrackConstraints) {


### PR DESCRIPTION
This PR is related to: https://github.com/signalwire/cloud-support/issues/1065. 
For the implementation, read this comment: https://github.com/signalwire/cloud-support/issues/1065#issuecomment-887024413

Until now we used a workaround for SS/Device room objects because the server didn't send `room.subscribed` for those connections. We discussed yesterday to consume the `member.joined` event and compare the `parent_id` (only there for screenShare/additionalDevice types). If the SDK has its parent_id in the state it means it's the owner of the object so we can update the state and reflect the changes in the _connected component_. 