### PR TITLE
Add ability to define middleware/transforms for the EventEmitter

### DIFF
--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -9,6 +9,7 @@ import {
   ExecuteExtendedOptions,
   EventsPrefix,
   EventTransform,
+  BaseEventHandler,
 } from './utils/interfaces'
 import { EventEmitter, getNamespacedEvent } from './utils/EventEmitter'
 import { SDKState } from './redux/interfaces'
@@ -33,7 +34,6 @@ type EventRegisterHandlers =
     }
 
 const identity: ExecuteTransform<any, any> = (payload) => payload
-type BaseEventHandler = (...args: any[]) => void
 
 export class BaseComponent implements Emitter {
   id = uuid()

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -126,9 +126,11 @@ export class BaseComponent implements Emitter {
     return handler
   }
 
-  private getStableEventHandler(fn?: (...args: any[]) => void) {
+  private getAndRemoveStableEventHandler(fn?: (...args: any[]) => void) {
     if (fn && this._emitterListenersCache.has(fn)) {
-      return this._emitterListenersCache.get(fn)
+      const handler = this._emitterListenersCache.get(fn)
+      this._emitterListenersCache.delete(fn)
+      return handler
     }
 
     return fn
@@ -167,7 +169,7 @@ export class BaseComponent implements Emitter {
     }
 
     const [event, fn, context, once] = params
-    const handler = this.getStableEventHandler(fn)
+    const handler = this.getAndRemoveStableEventHandler(fn)
     const namespacedEvent = this._getNamespacedEvent(event)
     logger.debug('Registering event', namespacedEvent)
     return this.emitter.off(namespacedEvent, handler, context, once)
@@ -203,6 +205,9 @@ export class BaseComponent implements Emitter {
         this.emitter.removeAllListeners(event)
       })
     }
+
+    logger.debug('Removing all cached listeners.')
+    this._emitterListenersCache.clear()
 
     return this.emitter as EventEmitter<string | symbol, any>
   }

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -127,7 +127,7 @@ export class BaseComponent implements Emitter {
   }
 
   private getStableEventHandler(fn?: (...args: any[]) => void) {
-    if (fn) {
+    if (fn && this._emitterListenersCache.has(fn)) {
       return this._emitterListenersCache.get(fn)
     }
 

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -67,8 +67,9 @@ export class BaseComponent implements Emitter {
    * Collection of functions that will be executed before calling the
    * event handlers registered by the end user (when using the Emitter
    * interface).
+   * @internal
    */
-  protected _emitterTransforms: Map<any, EventTransform> = new Map()
+  protected _emitterTransforms: Map<string | symbol, EventTransform> = new Map()
   /**
    * Keeps track of the stable references used for registering events
    */
@@ -119,6 +120,10 @@ export class BaseComponent implements Emitter {
     event: string | symbol,
     fn: (...args: any[]) => void
   ) {
+    /**
+     * Transforms are mapped using the "raw" event name (meaning, the
+     * same event the end user will be consuming, i.e non-namespaced)
+     */
     const transform = this._emitterTransforms.get(event)
     const handler = transform ? transform(fn) : fn
     this._emitterListenersCache.set(fn, handler)

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -212,3 +212,7 @@ export type RoomCustomMethods<T> = {
 }
 
 export type EventsPrefix = '' | 'video.'
+
+export type EventTransform = <InputType>(
+  handler: any
+) => (payload: InputType) => ReturnType<typeof handler>

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -216,3 +216,5 @@ export type EventsPrefix = '' | 'video.'
 export type EventTransform = <InputType>(
   handler: any
 ) => (payload: InputType) => ReturnType<typeof handler>
+
+export type BaseEventHandler = (...args: any[]) => void

--- a/packages/node/src/Client.ts
+++ b/packages/node/src/Client.ts
@@ -4,6 +4,7 @@ import {
   logger,
   SessionState,
   GlobalVideoEvents,
+  EventTransform,
 } from '@signalwire/core'
 
 interface Consumer {
@@ -12,6 +13,23 @@ interface Consumer {
 }
 export class Client extends BaseClient {
   private _consumers: Consumer[] = []
+
+  // TODO: Remove: This is just for demo purposes. We'll remove it
+  // until we have the logic for instantiating Room objects
+  _emitterTransforms = new Map<GlobalVideoEvents, EventTransform>([
+    [
+      'room.started',
+      (handler: any) => (payload) => {
+        /**
+         * Note: `handler` is the function used by the user to register to the event.
+         * For now this transform is not doing anything with the
+         * payload, but we could do anything we want before calling
+         * the `handler`.
+         */
+        return handler(payload)
+      },
+    ],
+  ])
 
   async onAuth(session: SessionState) {
     if (session.authStatus === 'authorized' && session.authCount > 1) {

--- a/packages/node/src/Client.ts
+++ b/packages/node/src/Client.ts
@@ -4,7 +4,6 @@ import {
   logger,
   SessionState,
   GlobalVideoEvents,
-  EventTransform,
 } from '@signalwire/core'
 
 interface Consumer {
@@ -13,23 +12,6 @@ interface Consumer {
 }
 export class Client extends BaseClient {
   private _consumers: Consumer[] = []
-
-  // TODO: Remove: This is just for demo purposes. We'll remove it
-  // until we have the logic for instantiating Room objects
-  _emitterTransforms = new Map<GlobalVideoEvents, EventTransform>([
-    [
-      'room.started',
-      (handler: any) => (payload) => {
-        /**
-         * Note: `handler` is the function used by the user to register to the event.
-         * For now this transform is not doing anything with the
-         * payload, but we could do anything we want before calling
-         * the `handler`.
-         */
-        return handler(payload)
-      },
-    ],
-  ])
 
   async onAuth(session: SessionState) {
     if (session.authStatus === 'authorized' && session.authCount > 1) {


### PR DESCRIPTION
The code in this changeset adds the ability to define (a sort-of) middleware for event handlers that are using the `EventEmitter` interface. 

Each class that extends from `BaseComponent` will have the option to use this new feature by defining a class property named `_emitterTransforms`.

#### Example:
```js
class Room extends BaseConnection implements BaseRoomInterface {
  ...
  protected _emitterTransforms = new Map<any, any>([
    [
      'member.talking',
      (handler: any) => (payload: any) => {
        // do some work with the payload.
        return handler(payload)
      },
    ],
  ])
 ...
}
```