### PR TITLE
Remove workaround for RoomDevice/RoomScreenShare objects - 2

### DIFF
--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -91,18 +91,9 @@ export class BaseConnection
   private state: BaseConnectionState = 'new'
   private prevState: BaseConnectionState = 'new'
 
-  /**
-   *  FIXME: Remove this workaround when
-   * we get room.subscribed for screenShare
-   * and device sessions.
-   */
-
-  /** @internal */
-  public _roomId: string
-  /** @internal */
-  public _roomSessionId: string
-  /** @internal */
-  public _memberId: string
+  private _roomId: string
+  private _roomSessionId: string
+  private _memberId: string
 
   constructor(options: BaseConnectionOptions) {
     super(options)


### PR DESCRIPTION
This is related to https://github.com/signalwire/signalwire-js/pull/211 - I missed this spot in that PR.