### PR TITLE
Set BaseConnection nodeId within onRoomSubscribed

### DIFF
--- a/.changeset/two-teachers-happen.md
+++ b/.changeset/two-teachers-happen.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/webrtc': patch
+---
+
+Fix: set internal nodeId for BaseConnection objects

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -262,6 +262,7 @@ export class BaseConnection
   /** @internal */
   public onRoomSubscribed(component: any) {
     logger.debug('onRoomSubscribed', component)
+    this.nodeId = component.nodeId
     this._roomId = component.roomId
     this._roomSessionId = component.roomSessionId
     this._memberId = component.memberId


### PR DESCRIPTION
~I will double check with Shane if this is still required with the latest changes in Blade 3.0.0.~

Confirmed that it's still required.