### PR TITLE
Update devices filtering logic

### DIFF
--- a/.changeset/pretty-scissors-camp.md
+++ b/.changeset/pretty-scissors-camp.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/webrtc': patch
+---
+
+Update the filtering logic for the device list where Firefox could return a device with `deviceId` but with empty `label`.

--- a/packages/webrtc/src/utils/deviceHelpers.test.ts
+++ b/packages/webrtc/src/utils/deviceHelpers.test.ts
@@ -67,12 +67,6 @@ describe('Helpers browser functions', () => {
       deviceId: 'uuid',
       kind: 'audioinput',
       label: '',
-      groupId: group1,
-    },
-    {
-      deviceId: 'uuid',
-      kind: 'audioinput',
-      label: '',
       groupId: group2,
     },
 
@@ -274,6 +268,17 @@ describe('Helpers browser functions', () => {
         expect(devices).toHaveLength(3)
         expect(devices.every((d) => d.deviceId && d.label)).toBe(true)
       })
+
+      it('should return the devices with at least deviceId - even w/o label', async () => {
+        // @ts-ignore
+        navigator.mediaDevices.enumerateDevices.mockResolvedValueOnce(
+          DEVICES_CAMERA_NO_LABELS
+        )
+        const devices = await getDevices()
+        expect(devices).toHaveLength(5)
+        expect(devices.every((d) => d.deviceId)).toBe(true)
+        expect(devices.filter((d) => !d.label)).toHaveLength(2)
+      })
     })
 
     describe('without microphone permissions', () => {
@@ -290,6 +295,17 @@ describe('Helpers browser functions', () => {
         const devices = await getDevices()
         expect(devices).toHaveLength(3)
         expect(devices.every((d) => d.deviceId && d.label)).toBe(true)
+      })
+
+      it('should return the devices with at least deviceId - even w/o label', async () => {
+        // @ts-ignore
+        navigator.mediaDevices.enumerateDevices.mockResolvedValueOnce(
+          DEVICES_MICROPHONE_NO_LABELS
+        )
+        const devices = await getDevices()
+        expect(devices).toHaveLength(5)
+        expect(devices.every((d) => d.deviceId)).toBe(true)
+        expect(devices.filter((d) => !d.label)).toHaveLength(2)
       })
     })
   })

--- a/packages/webrtc/src/utils/deviceHelpers.test.ts
+++ b/packages/webrtc/src/utils/deviceHelpers.test.ts
@@ -6,27 +6,26 @@ import {
 } from './deviceHelpers'
 
 describe('Helpers browser functions', () => {
+  const group1 = 'group1'
+  const group2 = 'group2'
   const DEVICES_CAMERA_NO_LABELS = [
     {
       deviceId: 'uuid',
       kind: 'audioinput',
       label: 'mic1',
-      groupId:
-        '83ef347b97d14abd837e8c6dbb819c5be84cfe0756dd41455b375cfd4c0ddb4f',
+      groupId: group1,
     },
     {
       deviceId: 'uuid',
       kind: 'audioinput',
       label: 'mic2',
-      groupId:
-        '83ef347b97d14abd837e8c6dbb819c5be84cfe0756dd41455b375cfd4c0ddb4f',
+      groupId: group1,
     },
     {
       deviceId: 'uuid',
       kind: 'audioinput',
       label: 'mic3',
-      groupId:
-        '67a612f4ac80c6c9854b50d664348e69b5a11421a0ba8d68e2c00f3539992b4c',
+      groupId: group2,
     },
 
     {
@@ -40,23 +39,20 @@ describe('Helpers browser functions', () => {
       deviceId: 'uuid',
       kind: 'videoinput',
       label: '',
-      groupId:
-        '67a612f4ac80c6c9854b50d664348e69b5a11421a0ba8d68e2c00f3539992b4c',
+      groupId: group2,
     },
 
     {
       deviceId: 'uuid',
       kind: 'audiooutput',
       label: 'speaker1',
-      groupId:
-        '83ef347b97d14abd837e8c6dbb819c5be84cfe0756dd41455b375cfd4c0ddb4f',
+      groupId: group1,
     },
     {
       deviceId: 'uuid',
       kind: 'audiooutput',
       label: 'speaker2',
-      groupId:
-        '83ef347b97d14abd837e8c6dbb819c5be84cfe0756dd41455b375cfd4c0ddb4f',
+      groupId: group1,
     },
   ]
 
@@ -65,22 +61,19 @@ describe('Helpers browser functions', () => {
       deviceId: 'uuid',
       kind: 'audioinput',
       label: '',
-      groupId:
-        '83ef347b97d14abd837e8c6dbb819c5be84cfe0756dd41455b375cfd4c0ddb4f',
+      groupId: group1,
     },
     {
       deviceId: 'uuid',
       kind: 'audioinput',
       label: '',
-      groupId:
-        '83ef347b97d14abd837e8c6dbb819c5be84cfe0756dd41455b375cfd4c0ddb4f',
+      groupId: group1,
     },
     {
       deviceId: 'uuid',
       kind: 'audioinput',
       label: '',
-      groupId:
-        '67a612f4ac80c6c9854b50d664348e69b5a11421a0ba8d68e2c00f3539992b4c',
+      groupId: group2,
     },
 
     {
@@ -94,23 +87,20 @@ describe('Helpers browser functions', () => {
       deviceId: 'uuid',
       kind: 'videoinput',
       label: 'camera2',
-      groupId:
-        '67a612f4ac80c6c9854b50d664348e69b5a11421a0ba8d68e2c00f3539992b4c',
+      groupId: group2,
     },
 
     {
       deviceId: 'uuid',
       kind: 'audiooutput',
       label: 'speaker1',
-      groupId:
-        '83ef347b97d14abd837e8c6dbb819c5be84cfe0756dd41455b375cfd4c0ddb4f',
+      groupId: group1,
     },
     {
       deviceId: 'uuid',
       kind: 'audiooutput',
       label: 'speaker2',
-      groupId:
-        '83ef347b97d14abd837e8c6dbb819c5be84cfe0756dd41455b375cfd4c0ddb4f',
+      groupId: group1,
     },
   ]
 
@@ -208,9 +198,7 @@ describe('Helpers browser functions', () => {
         expect(devices[0].label).toEqual(
           'Default - External Microphone (Built-in)'
         )
-        expect(
-          devices.every((d: MediaDeviceInfo) => d.deviceId && d.label)
-        ).toBe(true)
+        expect(devices.every((d) => d.deviceId && d.label)).toBe(true)
       })
     })
 
@@ -230,9 +218,7 @@ describe('Helpers browser functions', () => {
         expect(devices[0].label).toEqual(
           'Default - External Microphone (Built-in)'
         )
-        expect(
-          devices.every((d: MediaDeviceInfo) => d.deviceId && d.label)
-        ).toBe(true)
+        expect(devices.every((d) => d.deviceId && d.label)).toBe(true)
       })
     })
   })
@@ -274,30 +260,34 @@ describe('Helpers browser functions', () => {
     })
 
     describe('without camera permissions', () => {
+      const mockedDevices = DEVICES_CAMERA_NO_LABELS.map((d) => ({
+        ...d,
+        deviceId: d.label,
+      }))
       it('should return device list removing devices without deviceId and label', async () => {
         // @ts-ignore
         navigator.mediaDevices.enumerateDevices.mockResolvedValueOnce(
-          DEVICES_CAMERA_NO_LABELS
+          mockedDevices
         )
         const devices = await getDevices()
         expect(devices).toHaveLength(3)
-        expect(
-          devices.every((d: MediaDeviceInfo) => d.deviceId && d.label)
-        ).toBe(true)
+        expect(devices.every((d) => d.deviceId && d.label)).toBe(true)
       })
     })
 
     describe('without microphone permissions', () => {
+      const mockedDevices = DEVICES_MICROPHONE_NO_LABELS.map((d) => ({
+        ...d,
+        deviceId: d.label,
+      }))
       it('should return device list removing devices without deviceId and label', async () => {
         // @ts-ignore
         navigator.mediaDevices.enumerateDevices.mockResolvedValueOnce(
-          DEVICES_MICROPHONE_NO_LABELS
+          mockedDevices
         )
         const devices = await getDevices()
         expect(devices).toHaveLength(3)
-        expect(
-          devices.every((d: MediaDeviceInfo) => d.deviceId && d.label)
-        ).toBe(true)
+        expect(devices.every((d) => d.deviceId && d.label)).toBe(true)
       })
     })
   })
@@ -334,8 +324,7 @@ describe('Helpers browser functions', () => {
           deviceId: 'uuid',
           kind: 'videoinput',
           label: 'camera2',
-          groupId:
-            '67a612f4ac80c6c9854b50d664348e69b5a11421a0ba8d68e2c00f3539992b4c',
+          groupId: group2,
         },
       ]
       // @ts-ignore
@@ -362,8 +351,7 @@ describe('Helpers browser functions', () => {
           deviceId: 'new-uuid',
           kind: 'videoinput',
           label: 'FaceTime HD Camera',
-          groupId:
-            '67a612f4ac80c6c9854b50d664348e69b5a11421a0ba8d68e2c00f3539992b4c',
+          groupId: group2,
         },
       ]
       // @ts-ignore

--- a/packages/webrtc/src/utils/deviceHelpers.test.ts
+++ b/packages/webrtc/src/utils/deviceHelpers.test.ts
@@ -262,7 +262,8 @@ describe('Helpers browser functions', () => {
     describe('without camera permissions', () => {
       const mockedDevices = DEVICES_CAMERA_NO_LABELS.map((d) => ({
         ...d,
-        deviceId: d.label,
+        // Set deviceId empty if there's no label
+        deviceId: d.label ? d.deviceId : '',
       }))
       it('should return device list removing devices without deviceId and label', async () => {
         // @ts-ignore
@@ -278,7 +279,8 @@ describe('Helpers browser functions', () => {
     describe('without microphone permissions', () => {
       const mockedDevices = DEVICES_MICROPHONE_NO_LABELS.map((d) => ({
         ...d,
-        deviceId: d.label,
+        // Set deviceId empty if there's no label
+        deviceId: d.label ? d.deviceId : '',
       }))
       it('should return device list removing devices without deviceId and label', async () => {
         // @ts-ignore

--- a/packages/webrtc/src/utils/deviceHelpers.ts
+++ b/packages/webrtc/src/utils/deviceHelpers.ts
@@ -103,12 +103,8 @@ const _filterDevices = (
   options: { excludeDefault?: boolean; targets?: MediaDeviceKind[] } = {}
 ) => {
   const found: string[] = []
-  return devices.filter(({ deviceId, label, kind, groupId }) => {
-    if (
-      !deviceId ||
-      !label ||
-      (options.targets && !options.targets?.includes(kind))
-    ) {
+  return devices.filter(({ deviceId, kind, groupId }) => {
+    if (!deviceId || (options.targets && !options.targets?.includes(kind))) {
       return false
     }
     if (!groupId) {
@@ -269,11 +265,10 @@ type TargetPermission = Record<
   [Partial<DevicePermissionName>, boolean][]
 >
 
-const CHECK_SUPPORT_MAP: Partial<
-  Record<DevicePermissionName, () => boolean>
-> = {
-  speaker: WebRTC.supportsMediaOutput,
-}
+const CHECK_SUPPORT_MAP: Partial<Record<DevicePermissionName, () => boolean>> =
+  {
+    speaker: WebRTC.supportsMediaOutput,
+  }
 
 const checkTargetPermissions = async (options: {
   targets?: DevicePermissionName[]
@@ -412,10 +407,8 @@ export const createDeviceWatcher = async (
   options: CreateDeviceWatcherOptions = {}
 ) => {
   const targets = await validateTargets({ targets: options.targets })
-  const emitter: StrictEventEmitter<
-    EventEmitter,
-    DeviceWatcherEvents
-  > = new EventEmitter()
+  const emitter: StrictEventEmitter<EventEmitter, DeviceWatcherEvents> =
+    new EventEmitter()
   const currentDevices = await WebRTC.enumerateDevices()
   const kinds = targets?.reduce((reducer, name) => {
     const kind = _getMediaDeviceKindByName(name)

--- a/packages/webrtc/src/utils/helpers.ts
+++ b/packages/webrtc/src/utils/helpers.ts
@@ -17,24 +17,6 @@ export const getUserMedia = async (constraints: MediaStreamConstraints) => {
   }
 }
 
-export const removeUnsupportedConstraints = (
-  constraints: MediaTrackConstraints
-): void => {
-  const supported = WebRTC.getSupportedConstraints()
-  Object.keys(constraints).map((key) => {
-    if (
-      !supported.hasOwnProperty(key) ||
-      // @ts-ignore
-      constraints[key] === null ||
-      // @ts-ignore
-      constraints[key] === undefined
-    ) {
-      // @ts-ignore
-      delete constraints[key]
-    }
-  })
-}
-
 export const getMediaConstraints = async (
   options: ConnectionOptions
 ): Promise<MediaStreamConstraints> => {
@@ -68,71 +50,3 @@ export const getMediaConstraints = async (
 
   return { audio, video }
 }
-
-type DestructuredResult = {
-  subscribed: string[]
-  alreadySubscribed: string[]
-  unauthorized: string[]
-  unsubscribed: string[]
-  notSubscribed: string[]
-}
-
-export const destructSubscribeResponse = (
-  response: any
-): DestructuredResult => {
-  const tmp: any = {
-    subscribed: [],
-    alreadySubscribed: [],
-    unauthorized: [],
-    unsubscribed: [],
-    notSubscribed: [],
-  }
-  Object.keys(tmp).forEach((k) => {
-    tmp[k] = response[`${k}Channels`] || []
-  })
-  return tmp
-}
-
-const _updateMediaStreamTracks = (
-  stream: MediaStream,
-  kind?: string,
-  enabled?: boolean
-) => {
-  if (!WebRTC.streamIsValid(stream)) {
-    return null
-  }
-  const _updateTrack = (track: MediaStreamTrack) => {
-    switch (enabled) {
-      case true:
-        track.enabled = true
-        break
-      case false:
-        track.enabled = false
-        break
-      default:
-        track.enabled = !track.enabled
-        break
-    }
-  }
-  switch (kind) {
-    case 'audio':
-      return stream.getAudioTracks().forEach(_updateTrack)
-    case 'video':
-      return stream.getVideoTracks().forEach(_updateTrack)
-    default:
-      return stream.getTracks().forEach(_updateTrack)
-  }
-}
-
-export const enableAudioTracks = (stream: MediaStream) =>
-  _updateMediaStreamTracks(stream, 'audio', true)
-export const disableAudioTracks = (stream: MediaStream) =>
-  _updateMediaStreamTracks(stream, 'audio', false)
-export const toggleAudioTracks = (stream: MediaStream) =>
-  _updateMediaStreamTracks(stream, 'audio')
-export const enableVideoTracks = (stream: MediaStream) =>
-  _updateMediaStreamTracks(stream, 'video', true)
-export const disableVideoTracks = (stream: MediaStream) =>
-  _updateMediaStreamTracks(stream, 'video', false)
-export const toggleVideoTracks = (stream: MediaStream) =>
-  _updateMediaStreamTracks(stream, 'video')


### PR DESCRIPTION
From: https://developer.mozilla.org/en-US/docs/Web/API/MediaDeviceInfo

```
For security reasons, the label field is always blank unless an active media stream exists or the user has granted persistent permission for media device access. The set of device labels could otherwise be used as part of a fingerprinting mechanism to identify a user.
```

In Firefox, if the user doesn't check a flag while giving permissions, the devices have no `label` at all (empty).
This breaks our logic where we filter out _invalid_ devices checking for `deviceId && label`.

In that specific case we can return what the browser give us so: only `deviceId` with empty labels.

**Note:** This should not be a "breaking change" for the end-user since Chromium and Webkit return `deviceId` and `label` when the user gave permissions. It's a requirement only for Firefox. 

Related to: https://github.com/signalwire/cloud-product/issues/2012