### PR TITLE
Update event list in verto.invite

### DIFF
--- a/packages/core/src/redux/features/executeQueue/executeQueueSaga.test.ts
+++ b/packages/core/src/redux/features/executeQueue/executeQueueSaga.test.ts
@@ -21,7 +21,7 @@ describe('executeQueueWatcher', () => {
       params: {
         event_channel: 'rooms',
         get_initial_state: true,
-        events: ['room.started', 'room.ended'],
+        events: ['video.room.started', 'video.room.ended'],
       },
     }
 
@@ -42,7 +42,7 @@ describe('executeQueueWatcher', () => {
       params: {
         event_channel: 'rooms',
         get_initial_state: true,
-        events: ['room.started', 'room.ended'],
+        events: ['video.room.started', 'video.room.ended'],
       },
     }
     const state = store.getState()

--- a/packages/core/src/redux/features/executeQueue/executeQueueSlice.test.ts
+++ b/packages/core/src/redux/features/executeQueue/executeQueueSlice.test.ts
@@ -20,7 +20,7 @@ describe('ExecuteQueueState Tests', () => {
       params: {
         event_channel: 'rooms',
         get_initial_state: true,
-        events: ['room.started', 'room.ended'],
+        events: ['video.room.started', 'video.room.ended'],
       },
     }
 
@@ -37,7 +37,7 @@ describe('ExecuteQueueState Tests', () => {
       params: {
         event_channel: 'rooms',
         get_initial_state: true,
-        events: ['room.started', 'room.ended'],
+        events: ['video.room.started', 'video.room.ended'],
       },
     }
     store.dispatch(executeQueueActions.add(payload))

--- a/packages/core/src/redux/features/pubSub/pubSubSaga.ts
+++ b/packages/core/src/redux/features/pubSub/pubSubSaga.ts
@@ -29,7 +29,7 @@ export function* pubSubSaga({
     try {
       const namespace = findNamespaceInPayload(payload)
       /**
-       * There are events (like `room.started`/`room.ended`) that can
+       * There are events (like `video.room.started`/`video.room.ended`) that can
        * be consumed from different places, like from a `roomObj`
        * (namespaced Event Emitter) or from a `client`
        * (non-namespaced/global Event Emitter) so we must trigger the

--- a/packages/core/src/redux/features/session/sessionSaga.test.ts
+++ b/packages/core/src/redux/features/session/sessionSaga.test.ts
@@ -8,7 +8,7 @@ import { createPubSubChannel } from '../../../testUtils'
 
 describe('sessionChannelWatcher', () => {
   describe('videoAPIWorker', () => {
-    it('should handle room.subscribed dispatching componentActions.upsert and the room.joined', async () => {
+    it('should handle video.room.subscribed dispatching componentActions.upsert and the room.joined', async () => {
       const jsonrpc = JSON.parse(
         '{"jsonrpc":"2.0","id":"83cbf7d3-4364-454e-af84-6f1f9176901b","method":"signalwire.event","params":{"params":{"room":{"room_session_id":"6fbe4472-e6dd-431f-887f-33171cd83ccb","logos_visible":true,"members":[{"visible":false,"room_session_id":"6fbe4472-e6dd-431f-887f-33171cd83ccb","input_volume":0,"id":"0e5f67e0-8dbf-48dd-b920-804b97fccee6","input_sensitivity":200,"output_volume":0,"audio_muted":false,"on_hold":false,"name":"Edo","deaf":false,"video_muted":false,"room_id":"790d6c79-f0d1-421e-b5f2-f09bd05941ce","type":"member"}],"blind_mode":false,"recording":false,"silent_mode":false,"name":"edoRoom2","hide_video_muted":false,"locked":false,"meeting_mode":false,"room_id":"790d6c79-f0d1-421e-b5f2-f09bd05941ce","event_channel":"room.649c069f-c0a1-4cc8-9d6a-be642ad68eab"},"call_id":"0e5f67e0-8dbf-48dd-b920-804b97fccee6","member_id":"0e5f67e0-8dbf-48dd-b920-804b97fccee6"},"timestamp":1627373985.2656,"event_type":"video.room.subscribed","event_channel":"room.649c069f-c0a1-4cc8-9d6a-be642ad68eab"}}'
       )
@@ -65,7 +65,7 @@ describe('sessionChannelWatcher', () => {
         })
     })
 
-    it('should handle member.updated dispatching the sub-events for what is changed for the user', async () => {
+    it('should handle video.member.updated dispatching the sub-events for what is changed for the user', async () => {
       const jsonrpc = JSON.parse(
         '{"jsonrpc":"2.0","id":"90e60fd9-a353-44dd-b179-4ce8f43b0cb1","method":"signalwire.event","params":{"params":{"room_session_id":"8e03ac25-8622-411a-95fc-f897b34ac9e7","room_id":"6e83849b-5cc2-4fc6-80ed-448113c8a426","member":{"updated":["visible","video_muted"],"room_session_id":"8e03ac25-8622-411a-95fc-f897b34ac9e7","id":"ab42641c-e784-42f1-9815-d264105bc24f","visible":true,"room_id":"6e83849b-5cc2-4fc6-80ed-448113c8a426","video_muted":false}},"timestamp":1627374437.3696,"event_type":"video.member.updated","event_channel":"room.0a324e3c-5e2f-443a-a333-10bf005f249e"}}'
       )
@@ -121,7 +121,7 @@ describe('sessionChannelWatcher', () => {
         })
     })
 
-    it('should handle member.talking and emit member.talking.start when talking: true', () => {
+    it('should handle video.member.talking and emit member.talking.start when talking: true', () => {
       const jsonrpc = JSON.parse(
         '{"jsonrpc":"2.0","id":"9050e4f8-b08e-4e39-9796-bfb6e83c2a2d","method":"signalwire.event","params":{"params":{"room_session_id":"8e03ac25-8622-411a-95fc-f897b34ac9e7","room_id":"6e83849b-5cc2-4fc6-80ed-448113c8a426","member":{"id":"a3693340-6f42-4cab-b18e-8e2a22695698","room_session_id":"8e03ac25-8622-411a-95fc-f897b34ac9e7","room_id":"6e83849b-5cc2-4fc6-80ed-448113c8a426","talking":true}},"timestamp":1627374612.9585,"event_type":"video.member.talking","event_channel":"room.0a324e3c-5e2f-443a-a333-10bf005f249e"}}'
       )
@@ -273,7 +273,7 @@ describe('sessionChannelWatcher', () => {
         })
     })
 
-    it('should handle member.joined without parent_id', async () => {
+    it('should handle video.member.joined without parent_id', async () => {
       const jsonrpc = JSON.parse(
         '{"jsonrpc":"2.0","id":"8719c452-fd1d-4fc6-aea8-d517caac70ed","method":"signalwire.event","params":{"params":{"room_session_id":"313bedbe-edc9-4653-b332-34fbf43e8289","room_id":"6e83849b-5cc2-4fc6-80ed-448113c8a426","member":{"visible":false,"room_session_id":"313bedbe-edc9-4653-b332-34fbf43e8289","input_volume":0,"id":"b8912cc5-4248-4345-b53c-d53b2761748d","scope_id":"e85c456f-1bf6-4e4c-8e8b-ee1f004226e5","input_sensitivity":200,"output_volume":0,"audio_muted":false,"on_hold":false,"name":"Edo","deaf":false,"video_muted":false,"room_id":"6e83849b-5cc2-4fc6-80ed-448113c8a426","type":"member"}},"timestamp":1627391485.1266,"event_type":"video.member.joined","event_channel":"room.ed1a0eb0-1e8e-44ca-88f9-7f89a6cfc9c7"}}'
       )
@@ -318,7 +318,7 @@ describe('sessionChannelWatcher', () => {
         })
     })
 
-    it('should handle member.joined without parent_id', async () => {
+    it('should handle video.member.joined without parent_id', async () => {
       const parentId = 'd815d293-f8d0-49e8-aec2-3a4cc3729af8'
       const jsonrpc = JSON.parse(
         `{"jsonrpc":"2.0","id":"8719c452-fd1d-4fc6-aea8-d517caac70ed","method":"signalwire.event","params":{"params":{"room_session_id":"313bedbe-edc9-4653-b332-34fbf43e8289","room_id":"6e83849b-5cc2-4fc6-80ed-448113c8a426","member":{"visible":false,"room_session_id":"313bedbe-edc9-4653-b332-34fbf43e8289","input_volume":0,"id":"b8912cc5-4248-4345-b53c-d53b2761748d","scope_id":"e85c456f-1bf6-4e4c-8e8b-ee1f004226e5","input_sensitivity":200,"output_volume":0,"audio_muted":false,"on_hold":false,"name":"Edo","deaf":false,"video_muted":false,"parent_id":"${parentId}","room_id":"6e83849b-5cc2-4fc6-80ed-448113c8a426","type":"screen"}},"timestamp":1627391485.1266,"event_type":"video.member.joined","event_channel":"room.ed1a0eb0-1e8e-44ca-88f9-7f89a6cfc9c7"}}`

--- a/packages/core/src/redux/features/session/sessionSaga.ts
+++ b/packages/core/src/redux/features/session/sessionSaga.ts
@@ -223,7 +223,7 @@ export function* sessionChannelWatcher({
       }
       case 'video.member.joined': {
         /**
-         * On member.joined with a parent_id, check if we are the
+         * On video.member.joined with a parent_id, check if we are the
          * owner of the object comparing parent_id in the state.
          * If so update the state with the room values to update the
          * object (= trigger `onRoomSubscribed`).

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -7,7 +7,7 @@ import {
   selectors,
   BaseComponentOptions,
   BaseConnectionState,
-  RoomEventNames,
+  InternalVideoEvent,
   Rooms,
   JSONRPCRequest,
 } from '@signalwire/core'
@@ -15,16 +15,16 @@ import RTCPeer from './RTCPeer'
 import { ConnectionOptions } from './utils/interfaces'
 import { stopStream, stopTrack, getUserMedia } from './utils/webrtcHelpers'
 
-const ROOM_EVENTS: RoomEventNames[] = [
-  'room.started',
-  'room.subscribed',
-  'room.updated',
-  'room.ended',
-  'member.joined',
-  'member.updated',
-  'member.left',
-  'member.talking',
-  'layout.changed',
+const ROOM_EVENTS: InternalVideoEvent[] = [
+  'video.room.started',
+  'video.room.subscribed',
+  'video.room.updated',
+  'video.room.ended',
+  'video.member.joined',
+  'video.member.updated',
+  'video.member.left',
+  'video.member.talking',
+  'video.layout.changed',
 ]
 
 /**
@@ -36,7 +36,7 @@ const SCREENSHARE_ROOM_EVENTS = [
    * This is not a real event, it's only being used for debugging
    * purposes
    */
-  'room.screenshare',
+  'video.room.screenshare',
 ]
 
 /**
@@ -48,7 +48,7 @@ const DEVICE_ROOM_EVENTS = [
    * This is not a real event, it's only being used for debugging
    * purposes
    */
-  'room.additionaldevice',
+  'video.room.additionaldevice',
 ]
 
 const DEFAULT_CALL_OPTIONS: ConnectionOptions = {


### PR DESCRIPTION
Now we require to send the events including the proper prefix.

Related to https://github.com/signalwire/cloud-support/issues/1121

- [x] Check other spots for events w/o namespace