### PR TITLE
Improve watch mode task for `core`

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,7 +29,9 @@
   },
   "homepage": "https://github.com/signalwire/signalwire-js/tree/master/packages/core",
   "scripts": {
-    "start": "sw-build --dev --web",
+    "start": "concurrently npm:start:*",
+    "start:web": "sw-build --dev --web",
+    "start:node": "sw-build --dev --node --watchFormat=cjs",
     "build": "tsc --project tsconfig.build.json && sw-build --web && sw-build --node",
     "test": "NODE_ENV=test jest",
     "prepare": "npm run build"

--- a/scripts/sw-build/index.js
+++ b/scripts/sw-build/index.js
@@ -288,6 +288,8 @@ const build = async ({ options, setupFile }) => {
   )
 }
 
+const getCleanFlagName = (flag) => flag.replace('--', '')
+
 export async function cli(args) {
   const flags = args.slice(2)
   /**
@@ -309,11 +311,15 @@ export async function cli(args) {
     )
     process.exit(1)
   }
-  if (isDevMode(flags)) {
-    console.log(`🟢 [${pkgJson.name}] Watch mode enabled`)
-  }
   const buildModeFlag = getBuildModeFlag(flags)
   const options = getBuildOptions({ flags, pkgJson })
+  if (isDevMode(flags)) {
+    console.log(
+      `🟢 [${pkgJson.name}] Watch mode for ${getCleanFlagName(
+        buildModeFlag
+      )} enabled`
+    )
+  }
   try {
     const results = await build({ options, setupFile })
     if (isUmdMode(flags)) {


### PR DESCRIPTION
The code in this changeset improves the default task for "watching" the `core` package. Since that package can be consumed from `node` and `web` and both need different bundles,  before this PR we needed to manually modify the `start` script to target a specific platform. This new script will automatically trigger the watch mode for both platforms using `concurrently`