### PR TITLE
Release Playback APIs

### DIFF
--- a/.changeset/gorgeous-turtles-return.md
+++ b/.changeset/gorgeous-turtles-return.md
@@ -1,6 +1,0 @@
----
-'@signalwire/core': patch
-'@signalwire/realtime-api': patch
----
-
-Upgrade dependency for handling WebSocket connections.

--- a/.changeset/little-pants-nail.md
+++ b/.changeset/little-pants-nail.md
@@ -1,7 +1,0 @@
----
-'@signalwire/core': minor
-'@signalwire/js': minor
-'@signalwire/realtime-api': minor
----
-
-Add support for the Playback APIs: `roomSession.play()` and the `RoomSessionPlayback` object to control it.

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] - 2021-10-12
+
+### Added
+
+- [#297](https://github.com/signalwire/signalwire-js/pull/297) [`2675e5e`](https://github.com/signalwire/signalwire-js/commit/2675e5ea1ce9247a9e9b525cacf365cb8e4374ca) - Add support for the Playback APIs: `roomSession.play()` and the `RoomSessionPlayback` object to control it.
+
+### Changed
+
+- [#325](https://github.com/signalwire/signalwire-js/pull/325) [`7d183de`](https://github.com/signalwire/signalwire-js/commit/7d183de47bae0e1f436609ab63704ec1888134a8) - Upgrade dependency for handling WebSocket connections.
+
 ## [3.1.4] - 2021-10-06
 
 ### Fixed

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "description": "Shared code for the SignalWire JS SDK",
   "author": "SignalWire Team <open.source@signalwire.com>",
   "license": "MIT",
-  "version": "3.1.4",
+  "version": "3.2.0",
   "main": "dist/index.node.js",
   "module": "dist/index.esm.js",
   "files": [

--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.0] - 2021-10-12
+
+### Added
+
+- [#297](https://github.com/signalwire/signalwire-js/pull/297) [`2675e5e`](https://github.com/signalwire/signalwire-js/commit/2675e5ea1ce9247a9e9b525cacf365cb8e4374ca) - Add support for the Playback APIs: `roomSession.play()` and the `RoomSessionPlayback` object to control it.
+
+### Dependencies
+
+- Updated dependencies [[`7d183de`](https://github.com/signalwire/signalwire-js/commit/7d183de47bae0e1f436609ab63704ec1888134a8), [`2675e5e`](https://github.com/signalwire/signalwire-js/commit/2675e5ea1ce9247a9e9b525cacf365cb8e4374ca)]:
+  - @signalwire/core@3.2.0
+  - @signalwire/webrtc@3.1.5
+
 ## [3.3.0] - 2021-10-06
 
 ### Deprecated

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -3,7 +3,7 @@
   "description": "SignalWire JS SDK",
   "author": "SignalWire Team <open.source@signalwire.com>",
   "license": "MIT",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "unpkg": "dist/index.umd.js",
@@ -43,8 +43,8 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@signalwire/core": "3.1.4",
-    "@signalwire/webrtc": "3.1.4"
+    "@signalwire/core": "3.2.0",
+    "@signalwire/webrtc": "3.1.5"
   },
   "types": "dist/js/src/index.d.ts"
 }

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -21,7 +21,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@signalwire/core": "3.1.4",
-    "@signalwire/webrtc": "3.1.4"
+    "@signalwire/core": "3.2.0",
+    "@signalwire/webrtc": "3.1.5"
   }
 }

--- a/packages/realtime-api/CHANGELOG.md
+++ b/packages/realtime-api/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0-beta.2] - 2021-10-12
+
+### Added
+
+- [#297](https://github.com/signalwire/signalwire-js/pull/297) [`2675e5e`](https://github.com/signalwire/signalwire-js/commit/2675e5ea1ce9247a9e9b525cacf365cb8e4374ca) - Add support for the Playback APIs: `roomSession.play()` and the `RoomSessionPlayback` object to control it.
+
+### Changed
+
+- [#325](https://github.com/signalwire/signalwire-js/pull/325) [`7d183de`](https://github.com/signalwire/signalwire-js/commit/7d183de47bae0e1f436609ab63704ec1888134a8) - Upgrade dependency for handling WebSocket connections.
+
+### Dependencies
+
+- Updated dependencies [[`7d183de`](https://github.com/signalwire/signalwire-js/commit/7d183de47bae0e1f436609ab63704ec1888134a8), [`2675e5e`](https://github.com/signalwire/signalwire-js/commit/2675e5ea1ce9247a9e9b525cacf365cb8e4374ca)]:
+  - @signalwire/core@3.2.0
+
 ## [3.0.0-beta.1] - 2021-10-06
 
 ### Changed

--- a/packages/realtime-api/package.json
+++ b/packages/realtime-api/package.json
@@ -3,7 +3,7 @@
   "description": "SignalWire RealTime SDK for Node.js",
   "author": "SignalWire Team <open.source@signalwire.com>",
   "license": "MIT",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0-beta.2",
   "main": "dist/index.node.js",
   "exports": {
     "require": "./dist/index.node.js",
@@ -41,7 +41,7 @@
     "docs:watch": "npm run docs -- --watch"
   },
   "dependencies": {
-    "@signalwire/core": "3.1.4",
+    "@signalwire/core": "3.2.0",
     "ws": "^8.2.3"
   },
   "devDependencies": {

--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -40,7 +40,7 @@
     "docs:watch": "npm run docs -- --watch"
   },
   "dependencies": {
-    "@signalwire/core": "3.1.4",
+    "@signalwire/core": "3.2.0",
     "node-abort-controller": "^2.0.0",
     "node-fetch": "^2.6.1"
   },

--- a/packages/webrtc/CHANGELOG.md
+++ b/packages/webrtc/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.5] - 2021-10-12
+
+### Dependencies
+
+- Updated dependencies [[`7d183de`](https://github.com/signalwire/signalwire-js/commit/7d183de47bae0e1f436609ab63704ec1888134a8), [`2675e5e`](https://github.com/signalwire/signalwire-js/commit/2675e5ea1ce9247a9e9b525cacf365cb8e4374ca)]:
+  - @signalwire/core@3.2.0
+
 ## [3.1.4] - 2021-10-06
 
 ### Fixed

--- a/packages/webrtc/package.json
+++ b/packages/webrtc/package.json
@@ -3,7 +3,7 @@
   "description": "SignalWire WebRTC library",
   "author": "SignalWire Team <open.source@signalwire.com>",
   "license": "MIT",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "main": "dist/cjs/webrtc/src/index.js",
   "module": "dist/mjs/webrtc/src/index.js",
   "files": [
@@ -39,7 +39,7 @@
     "docs:watch": "npm run docs -- --watch"
   },
   "dependencies": {
-    "@signalwire/core": "3.1.4"
+    "@signalwire/core": "3.2.0"
   },
   "types": "dist/cjs/webrtc/src/index.d.ts"
 }


### PR DESCRIPTION
This PR releases the Playback APIs for both `@signalwire/js` and `@signalwire/realtime-api`.

 - [x] docs
   - [ ] publish
 - [x] release notes
   - [ ] publish