### PR TITLE
Fix `js` localOverlay cache issue

### DIFF
--- a/.changeset/lovely-meals-learn.md
+++ b/.changeset/lovely-meals-learn.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': patch
+---
+
+Fix a possible race condition when applying the localVideo overlay

--- a/packages/js/src/utils/videoElement.ts
+++ b/packages/js/src/utils/videoElement.ts
@@ -89,7 +89,7 @@ const makeLayoutChangedHandler =
 
       let myLayer = layerMap.get(myMemberId)
       if (!myLayer) {
-        const myLayer = await _buildLayer({ element, location: layer })
+        myLayer = await _buildLayer({ element, location: layer })
         myLayer.id = myMemberId
 
         const localVideo = buildVideo()
@@ -99,11 +99,11 @@ const makeLayoutChangedHandler =
 
         myLayer.appendChild(localVideo)
 
-        layerMap.set(myMemberId, myLayer)
         const mcuLayers = rootElement.querySelector('.mcuLayers')
         const exists = document.getElementById(myMemberId)
         if (mcuLayers && !exists) {
           mcuLayers.appendChild(myLayer)
+          layerMap.set(myMemberId, myLayer)
         }
 
         return


### PR DESCRIPTION
Set the value within `layerMap` only when appended to the DOM. 