### PR TITLE
Update recording transforms

### DIFF
--- a/packages/js/src/BaseRoomSession.test.ts
+++ b/packages/js/src/BaseRoomSession.test.ts
@@ -87,7 +87,9 @@ describe('Room Object', () => {
       ;(room.execute as jest.Mock).mockResolvedValueOnce({
         code: '200',
         message: 'Recording started',
-        recording_id: 'c22d7223-5a01-49fe-8da0-46bec8e75e32',
+        recording: {
+          id: 'c22d7223-5a01-49fe-8da0-46bec8e75e32',
+        },
       })
 
       const recording = await room.startRecording()
@@ -131,13 +133,17 @@ describe('Room Object', () => {
       ;(room.execute as jest.Mock).mockResolvedValueOnce({
         code: '200',
         message: 'Recording started',
-        recording_id: 'first-recording',
+        recording: {
+          id: 'first-recording',
+        },
       })
       // @ts-expect-error
       ;(room.execute as jest.Mock).mockResolvedValueOnce({
         code: '200',
         message: 'Recording started',
-        recording_id: 'second-recording',
+        recording: {
+          id: 'second-recording',
+        },
       })
 
       const firstRecording = await room.startRecording()

--- a/packages/js/src/BaseRoomSession.ts
+++ b/packages/js/src/BaseRoomSession.ts
@@ -87,15 +87,8 @@ export class RoomSessionConnection
             })
           },
           payloadTransform: (payload: any) => {
-            if (payload?.recording) {
-              return toExternalJSON({
-                ...payload.recording,
-                room_session_id: this.roomSessionId,
-              })
-            }
-
             return toExternalJSON({
-              id: payload.recording_id,
+              ...payload.recording,
               room_session_id: this.roomSessionId,
             })
           },

--- a/packages/realtime-api/src/video/RoomSession.test.ts
+++ b/packages/realtime-api/src/video/RoomSession.test.ts
@@ -68,7 +68,6 @@ describe('RoomSession Object', () => {
   it('startRecording should return a recording object', async () => {
     // @ts-expect-error
     roomSession.execute = jest.fn().mockResolvedValue({
-      recording_id: 'recordingId',
       room_session_id: roomSessionId,
       room_id: 'roomId',
       recording: {

--- a/packages/realtime-api/src/video/RoomSession.ts
+++ b/packages/realtime-api/src/video/RoomSession.ts
@@ -632,15 +632,8 @@ class RoomSessionConsumer extends BaseConsumer<RealTimeRoomApiEvents> {
             })
           },
           payloadTransform: (payload: any) => {
-            if (payload?.recording) {
-              return toExternalJSON({
-                ...payload.recording,
-                room_session_id: payload.room_session_id,
-              })
-            }
-
             return toExternalJSON({
-              id: payload.recording_id,
+              ...payload.recording,
               room_session_id: payload.room_session_id,
             })
           },


### PR DESCRIPTION
The code in this changeset updates the recording transforms to always make use of the `recording` object instead of the `recording_id` prop.