### PR TITLE
Add option to install dependencies to our release cli

### DIFF
--- a/scripts/sw-release/common.js
+++ b/scripts/sw-release/common.js
@@ -35,7 +35,7 @@ const getBuildTask = ({ dryRun, executer }) => {
   let tasks = []
   return [
     {
-      title: '🏗️  Build all packages...',
+      title: '🏗️  Build all packages',
       task: async (_ctx, task) => {
         task.title = '🏗️  Building all packages...'
         try {
@@ -66,7 +66,7 @@ const getTestTask = ({ dryRun, executer }) => {
 
   return [
     {
-      title: '🧪 Run test suites...',
+      title: '🧪 Run test suites',
       task: (_ctx, task) => {
         task.title = '🧪 Running test suites...'
         return task.newListr((parentTask) => {
@@ -99,6 +99,37 @@ const getTestTask = ({ dryRun, executer }) => {
             }
           })
         })
+      },
+    },
+    getDryRunInfoTask({ dryRun, tasks }),
+  ]
+}
+
+const getInstallDependenciesTask = ({ flags, dryRun, executer }) => {
+  let tasks = []
+  const skipDeps = isSkipDeps(flags)
+
+  return [
+    {
+      skip: skipDeps,
+      title: '📦  Install packages',
+      task: async (_ctx, task) => {
+        task.title = '📦  Installing packages...'
+        try {
+          tasks.push(
+            await executer('npm', ['install'], {
+              cwd: ROOT_DIR,
+            })
+          )
+          if (dryRun) {
+            task.title = 'ℹ️  [Dry Run] Install Tasks:'
+          } else {
+            task.title = '📦  Packages installed successfully!'
+          }
+        } catch (e) {
+          task.title = '🛑 Install failed.'
+          throw e
+        }
       },
     },
     getDryRunInfoTask({ dryRun, tasks }),
@@ -277,22 +308,27 @@ const getModeFlag = (flags = []) => {
   return flags.find((f) => isModeFlag(f))
 }
 
-const MODIFIERS = ['--ci']
+const MODIFIERS = ['--ci', '--skip-deps']
 const getModifierFlags = (flags = []) => {
   return flags.filter((f) => MODIFIERS.includes(f))
 }
 const isCI = (flags = []) => {
   return getModifierFlags(flags).includes('--ci')
 }
+const isSkipDeps = (flags = []) => {
+  return getModifierFlags(flags).includes('--skip-deps')
+}
 
 export {
   getBuildTask,
   getDryRunInfoTask,
+  getInstallDependenciesTask,
   getModeFlag,
   getModifierFlags,
   getReleaseType,
   getTestTask,
   isCI,
+  isSkipDeps,
   publishTaskFactory,
   ROOT_DIR,
 }

--- a/scripts/sw-release/modes/beta.js
+++ b/scripts/sw-release/modes/beta.js
@@ -1,13 +1,15 @@
 import execa from 'execa'
 import {
   getBuildTask,
+  getInstallDependenciesTask,
   getTestTask,
-  ROOT_DIR,
   publishTaskFactory,
+  ROOT_DIR,
 } from '../common.js'
 
-const getBetaTasks = ({ dryRun, executer }) => {
+const getBetaTasks = ({ flags, dryRun, executer }) => {
   return [
+    ...getInstallDependenciesTask({ flags, dryRun, executer }),
     ...getBuildTask({ dryRun, executer }),
     ...getTestTask({ dryRun, executer }),
     {

--- a/scripts/sw-release/modes/development.js
+++ b/scripts/sw-release/modes/development.js
@@ -2,9 +2,10 @@ import execa from 'execa'
 import { getLastGitSha } from '@sw-internal/common'
 import {
   getBuildTask,
+  getInstallDependenciesTask,
   getTestTask,
-  ROOT_DIR,
   publishTaskFactory,
+  ROOT_DIR,
 } from '../common.js'
 
 const getDevVersion = async () => {
@@ -25,8 +26,9 @@ const getDevVersion = async () => {
   return `dev.${timestamp}.${sha}`
 }
 
-const getDevelopmentTasks = ({ dryRun, executer }) => {
+const getDevelopmentTasks = ({ flags, dryRun, executer }) => {
   return [
+    ...getInstallDependenciesTask({ flags, dryRun, executer }),
     ...getBuildTask({ dryRun, executer }),
     ...getTestTask({ dryRun, executer }),
     {

--- a/scripts/sw-release/modes/prepareProd.js
+++ b/scripts/sw-release/modes/prepareProd.js
@@ -1,7 +1,13 @@
-import { getBuildTask, getTestTask, ROOT_DIR } from '../common.js'
+import {
+  getBuildTask,
+  getInstallDependenciesTask,
+  getTestTask,
+  ROOT_DIR,
+} from '../common.js'
 
-const getPrepareProductionTasks = ({ dryRun, executer }) => {
+const getPrepareProductionTasks = ({ flags, dryRun, executer }) => {
   return [
+    ...getInstallDependenciesTask({ flags, dryRun, executer }),
     ...getBuildTask({ dryRun, executer }),
     ...getTestTask({ dryRun, executer }),
     {

--- a/scripts/sw-release/modes/production.js
+++ b/scripts/sw-release/modes/production.js
@@ -1,7 +1,12 @@
 import { isCleanGitStatus } from '@sw-internal/common'
-import { getBuildTask, getTestTask, publishTaskFactory } from '../common.js'
+import {
+  getBuildTask,
+  getInstallDependenciesTask,
+  getTestTask,
+  publishTaskFactory,
+} from '../common.js'
 
-const getProductionTasks = ({ executer, dryRun }) => {
+const getProductionTasks = ({ flags, executer, dryRun }) => {
   return [
     {
       title: '🔍 Checking Git status',
@@ -16,6 +21,7 @@ const getProductionTasks = ({ executer, dryRun }) => {
         }
       },
     },
+    ...getInstallDependenciesTask({ flags, dryRun, executer }),
     ...getBuildTask({ dryRun, executer }),
     ...getTestTask({ dryRun, executer }),
     ...publishTaskFactory({


### PR DESCRIPTION
The code in this changeset adds the option to run a `npm install` before releasing a package (for `beta`, `development` and `production`. To avoid having to install deps on every run you could by pass it by adding `--skip-deps`. 