### PR TITLE
Remove BaseSession queue + handle task cancellation

### DIFF
--- a/packages/core/src/redux/features/session/sessionSaga.ts
+++ b/packages/core/src/redux/features/session/sessionSaga.ts
@@ -103,14 +103,14 @@ export function* executeActionWatcher(session: BaseSession): SagaIterator {
       if (isCancelled && componentId && requestId) {
         const error: JSONRPCResponse = {
           jsonrpc: '2.0',
-          id: componentId,
+          id: requestId,
           error: {
             // Invalid Request
             code: -32600,
             message: 'Cancelled task',
           },
         }
-        logger.warn('worker cancelled', componentId, error)
+        logger.debug('worker cancelled', { requestId, componentId, error })
         yield put(
           componentActions.executeFailure({
             componentId,

--- a/packages/core/src/redux/features/session/sessionSaga.ts
+++ b/packages/core/src/redux/features/session/sessionSaga.ts
@@ -110,7 +110,11 @@ export function* executeActionWatcher(session: BaseSession): SagaIterator {
             message: 'Cancelled task',
           },
         }
-        logger.debug('worker cancelled', { requestId, componentId, error })
+        logger.debug('executeActionWorker cancelled', {
+          requestId,
+          componentId,
+          error,
+        })
         yield put(
           componentActions.executeFailure({
             componentId,

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -112,11 +112,6 @@ export interface SessionRequestObject {
   reject: (value: unknown) => void
 }
 
-export interface SessionRequestQueued {
-  resolve: (value: unknown) => void
-  msg: JSONRPCRequest | JSONRPCResponse
-}
-
 interface Authorization {
   type: 'video'
   project: string


### PR DESCRIPTION
The code in this changeset includes:

* Removal of the internal `BaseSession` queue: This queue was no longer needed since we introduced the queueing mechanism through sagas.
* Added ability to track cancelled `execute` tasks