### PR TITLE
Fix issue with clients not being able to connect without previous gUM

### DIFF
--- a/.changeset/gold-apes-pay.md
+++ b/.changeset/gold-apes-pay.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/webrtc': patch
+---
+
+Fix issue with connection not being able to stablish when video/audio permissions were not granted.

--- a/packages/webrtc/src/RTCPeer.ts
+++ b/packages/webrtc/src/RTCPeer.ts
@@ -309,12 +309,26 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
     }
   }
 
+  private _setupRTCPeerConnection() {
+    this.instance = RTCPeerConnection(this.config)
+    this._attachListeners()
+  }
+
   async start() {
     return new Promise(async (resolve, reject) => {
       this._resolveStartMethod = resolve
       this._rejectStartMethod = reject
 
       this.options.localStream = await this._retrieveLocalStream()
+
+      /**
+       * We need to defer the creation of RTCPeerConnection
+       * until we gain gUM access otherwise it will have
+       * private IP addresses in ICE host candidates
+       * replaced by an mDNS hostname
+       * @see https://groups.google.com/g/discuss-webrtc/c/6stQXi72BEU?pli=1
+       */
+      this._setupRTCPeerConnection()
 
       const { localStream = null } = this.options
       if (localStream && streamIsValid(localStream)) {

--- a/packages/webrtc/src/RTCPeer.ts
+++ b/packages/webrtc/src/RTCPeer.ts
@@ -310,8 +310,10 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
   }
 
   private _setupRTCPeerConnection() {
-    this.instance = RTCPeerConnection(this.config)
-    this._attachListeners()
+    if (!this.instance) {
+      this.instance = RTCPeerConnection(this.config)
+      this._attachListeners()
+    }
   }
 
   async start() {

--- a/packages/webrtc/src/RTCPeer.ts
+++ b/packages/webrtc/src/RTCPeer.ts
@@ -36,8 +36,6 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
     logger.debug('New Peer with type:', this.type, 'Options:', this.options)
 
     this._onIce = this._onIce.bind(this)
-    this.instance = RTCPeerConnection(this.config)
-    this._attachListeners()
   }
 
   get isOffer() {


### PR DESCRIPTION
The code in this changeset includes a fix for the issue where clients weren't able to connect right after giving consent to `getUserMedia` for the first time.

More info about why this was even an issue [here](https://groups.google.com/g/discuss-webrtc/c/6stQXi72BEU?pli=1) and [here](https://bloggeek.me/psa-mdns-and-local-ice-candidates-are-coming/)