### PR TITLE
[CF SDK]: Support muting/unmuting audio and video for all participants

### DIFF
--- a/.changeset/violet-teeth-slide.md
+++ b/.changeset/violet-teeth-slide.md
@@ -15,5 +15,5 @@ await audioUnute({ memberId: "all" })
 await videoMute({ memberId: "all" })
 
 // Unmute all members’ video
-await videoMute({ memberId: "all" })
+await videoUnmute({ memberId: "all" })
 ```

--- a/.changeset/violet-teeth-slide.md
+++ b/.changeset/violet-teeth-slide.md
@@ -5,15 +5,15 @@
 [CF SDK]: Support muting/unmuting audio and video for all participants
 
 ```ts
-// Mute all members’ audio
+// Mute audio for all participants in the room
 await audioMute({ memberId: "all" })
 
-// Unmute all members’ audio
+// Unmute audio for all participants in the room
 await audioUnmute({ memberId: "all" })
 
-// Mute all members’ video
+// Mute video for all participants in the room
 await videoMute({ memberId: "all" })
 
-// Unmute all members’ video
+// Unmute video for all participants in the room
 await videoUnmute({ memberId: "all" })
 ```

--- a/.changeset/violet-teeth-slide.md
+++ b/.changeset/violet-teeth-slide.md
@@ -9,7 +9,7 @@
 await audioMute({ memberId: "all" })
 
 // Unmute all members’ audio
-await audioUnute({ memberId: "all" })
+await audioUnmute({ memberId: "all" })
 
 // Mute all members’ video
 await videoMute({ memberId: "all" })

--- a/.changeset/violet-teeth-slide.md
+++ b/.changeset/violet-teeth-slide.md
@@ -1,0 +1,19 @@
+---
+'@signalwire/js': minor
+---
+
+[CF SDK]: Support muting/unmuting audio and video for all participants
+
+```ts
+// Mute all members’ audio
+await audioMute({ memberId: "all" })
+
+// Unmute all members’ audio
+await audioUnute({ memberId: "all" })
+
+// Mute all members’ video
+await videoMute({ memberId: "all" })
+
+// Unmute all members’ video
+await videoMute({ memberId: "all" })
+```

--- a/internal/e2e-js/playwright.config.ts
+++ b/internal/e2e-js/playwright.config.ts
@@ -45,6 +45,7 @@ const callfabricTests = [
   'deviceState.spec.ts',
   'holdunhold.spec.ts',
   'mirrorVideo.spec.ts',
+  'muteUnmuteAll.spec.ts',
   'raiseHand.spec.ts',
   'reattach.spec.ts',
   'relayApp.spec.ts',

--- a/internal/e2e-js/tests/callfabric/muteUnmuteAll.spec.ts
+++ b/internal/e2e-js/tests/callfabric/muteUnmuteAll.spec.ts
@@ -9,184 +9,267 @@ import {
 } from '../../utils'
 import { CallJoinedEventParams, FabricRoomSession } from '@signalwire/js'
 
-const waitForAudioMutedChange = (
+type NamedPage = { name: string; page: Page }
+const pageNames = [
+  '[pageOne]',
+  '[pageTwo]',
+  '[pageThree]',
+  '[pageFour]',
+] as const
+
+const joinAllPages = async (
+  channel: 'audio' | 'video',
+  createCustomPage: any,
+  resource: any
+) => {
+  const allPages: NamedPage[] = await Promise.all(
+    pageNames.map(async (name) => {
+      const page = await createCustomPage({ name })
+      await page.goto(SERVER_URL)
+      return { name, page }
+    })
+  )
+
+  const roomName = `e2e-${channel}-room-${uuid()}`
+  await resource.createVideoRoomResource(roomName)
+  const address = `/public/${roomName}?channel=${channel}`
+
+  const roomSessions = []
+  for (const { name, page } of allPages) {
+    const roomSession =
+      await test.step(`${name} create a client and join ${channel} room`, async () => {
+        await createCFClient(page)
+        const rs = await dialAddress(page, { address })
+        expect(rs.room_session).toBeDefined()
+        expect(rs.room_session.members).toBeDefined()
+
+        if (channel === 'video') {
+          await expectMCUVisible(page)
+        }
+
+        return rs
+      })
+    roomSessions.push(roomSession)
+  }
+
+  return { allPages, roomSessions, address }
+}
+
+const waitForMutedChange = (
   page: Page,
   memberId: string,
-  shouldBeMuted: boolean
+  field: 'audio_muted' | 'video_muted',
+  expected: boolean
 ): Promise<[boolean, boolean]> => {
   return page.evaluate(
-    ({ memberId, shouldBeMuted }) => {
+    ({ memberId, field, expected }) => {
+      const eventSuffix = field === 'audio_muted' ? 'audioMuted' : 'videoMuted'
+
       // @ts-expect-error
       const roomObj: FabricRoomSession = window._roomObj
 
-      const memberUpdatedEvent = new Promise<boolean>((resolve) => {
+      const p1 = new Promise<boolean>((resolve) => {
         roomObj.on('member.updated', (e) => {
-          if (
-            e.member.member_id === memberId &&
-            e.member.audio_muted === shouldBeMuted
-          ) {
+          if (e.member.member_id === memberId && e.member[field] === expected) {
             resolve(true)
           }
         })
       })
 
-      const memberAudioMutedEvent = new Promise<boolean>((resolve) => {
-        roomObj.on('member.updated.audioMuted', (e) => {
-          if (
-            e.member.member_id === memberId &&
-            e.member.audio_muted === shouldBeMuted
-          ) {
+      const p2 = new Promise<boolean>((resolve) => {
+        roomObj.on(`member.updated.${eventSuffix}`, (e) => {
+          if (e.member.member_id === memberId && e.member[field] === expected) {
             resolve(true)
           }
         })
       })
 
-      return Promise.all([memberUpdatedEvent, memberAudioMutedEvent])
+      return Promise.all([p1, p2])
     },
-    { memberId, shouldBeMuted }
+    { memberId, field, expected }
   )
 }
 
 test.describe('CallFabric - Mute/Unmute All', () => {
   const scenarios = [
-    { name: 'Audio-only', channel: 'audio', expectMCU: false },
-    { name: 'Video', channel: 'video', expectMCU: true },
+    { name: 'Audio-only', channel: 'audio' },
+    { name: 'Video', channel: 'video' },
   ] as const
 
-  for (const { name, channel, expectMCU } of scenarios) {
-    test.describe(`${name} room`, () => {
-      test('should mute/unmute all members audio, reload and reattach with correct states', async ({
+  for (const { name, channel } of scenarios) {
+    test(`${name} room: audio mute/unmute persists across reload & reattach`, async ({
+      createCustomPage,
+      resource,
+    }) => {
+      const { allPages, roomSessions, address } = await joinAllPages(
+        channel,
         createCustomPage,
-        resource,
-      }) => {
-        const pageNames = [
-          '[pageOne]',
-          '[pageTwo]',
-          '[pageThree]',
-          '[pageFour]',
-        ] as const
+        resource
+      )
+      expect(roomSessions).toHaveLength(4)
 
-        type NamedPage = { name: (typeof pageNames)[number]; page: Page }
-        const allPages: NamedPage[] = await Promise.all(
-          pageNames.map(async (name) => {
-            const page = await createCustomPage({ name })
-            return { name, page }
-          })
+      const [pageOne, pageTwo, pageThree, pageFour] = allPages.map(
+        (p) => p.page
+      )
+
+      // --------------- Attach listeners on all pages ---------------
+      const muteListeners = allPages.map(({ page }, i) =>
+        waitForMutedChange(page, roomSessions[i].member_id, 'audio_muted', true)
+      )
+
+      // ----------------- Mute Audio (pageOne) ----------------------
+      await test.step('[pageOne] mute all members audio', async () => {
+        await pageOne.evaluate(async () => {
+          // @ts-expect-error
+          await window._roomObj.audioMute({ memberId: 'all' })
+        })
+      })
+
+      await test.step('all pages should receive the memeber.updated events for mute', async () => {
+        await Promise.all(muteListeners)
+      })
+
+      // --------------- Reload and Reattach (pageTwo) ----------------
+      const roomSessionTwoAfter: CallJoinedEventParams =
+        await test.step('[pageTwo] reload page and reattach', async () => {
+          return reloadAndReattachAddress(pageTwo, { address })
+        })
+
+      await test.step('[pageTwo] assert room state', async () => {
+        expect(roomSessionTwoAfter.room_session).toBeDefined()
+        expect(roomSessionTwoAfter.call_id).toEqual(roomSessions[1].call_id)
+        expect(roomSessionTwoAfter.room_session.members).toHaveLength(4)
+
+        // Expect all members are muted
+        roomSessionTwoAfter.room_session.members.forEach((member) => {
+          expect(member).toBeDefined()
+          expect(member.audio_muted).toBe(true)
+        })
+      })
+
+      // --------------- Attach listeners on all pages ---------------
+      const unmuteListeners = allPages.map(({ page }, i) =>
+        waitForMutedChange(
+          page,
+          roomSessions[i].member_id,
+          'audio_muted',
+          false
         )
+      )
 
-        await Promise.all(allPages.map(({ page }) => page.goto(SERVER_URL)))
+      // ----------------- Unmute Audio (pageThree) ---------------------
+      await test.step('[pageThree] unmute all members audio', async () => {
+        await pageThree.evaluate(async () => {
+          // @ts-expect-error
+          await window._roomObj.audioUnmute({ memberId: 'all' })
+        })
+      })
 
-        const roomName = `e2e-${channel}-room-${uuid()}`
-        await resource.createVideoRoomResource(roomName)
-        const address = `/public/${roomName}?channel=${channel}`
+      await test.step('all pages should receive the memeber.updated events for unmute', async () => {
+        await Promise.all(unmuteListeners)
+      })
 
-        const allRoomSessions: CallJoinedEventParams[] = []
-        for (const { name, page } of allPages) {
-          const roomSession =
-            await test.step(`${name} create client and join a room`, async () => {
-              await createCFClient(page)
-
-              const roomSession: CallJoinedEventParams = await dialAddress(
-                page,
-                {
-                  address,
-                }
-              )
-
-              expect(roomSession.room_session).toBeDefined()
-              expect(roomSession.room_session.members).toBeDefined()
-
-              if (expectMCU) await expectMCUVisible(page)
-
-              return roomSession
-            })
-          allRoomSessions.push(roomSession)
-        }
-        expect(allRoomSessions).toHaveLength(4)
-
-        const [
-          { page: pageOne },
-          { page: pageTwo },
-          { page: pageThree },
-          { page: pageFour },
-        ] = allPages
-
-        // --------------- Attach listeners on all pages ---------------
-        const muteListeners = allPages.map(({ page }, i) =>
-          waitForAudioMutedChange(page, allRoomSessions[i].member_id, true)
-        )
-
-        // ----------------- Mute Audio (pageOne) ----------------------
-        await test.step('[pageOne] mute all members audio', async () => {
-          await pageOne.evaluate(async () => {
-            // @ts-expect-error
-            const roomObj: FabricRoomSession = window._roomObj
-            await roomObj.audioMute({ memberId: 'all' })
-          })
+      // --------------- Reload and Reattach (pageFour) ----------------
+      const roomSessionFourAfter: CallJoinedEventParams =
+        await test.step('[pageFour] reload page and reattach', async () => {
+          return reloadAndReattachAddress(pageFour, { address })
         })
 
-        await test.step('all pages should receive the memeber.updated events for mute', async () => {
-          await Promise.all(muteListeners)
-        })
+      await test.step('[pageFour] assert room state', async () => {
+        expect(roomSessionFourAfter.room_session).toBeDefined()
+        expect(roomSessionFourAfter.call_id).toEqual(roomSessions[3].call_id)
+        expect(roomSessionFourAfter.room_session.members).toHaveLength(4)
 
-        // --------------- Reload and Reattach (pageTwo) ----------------
-        const roomSessionTwoAfter: CallJoinedEventParams =
-          await test.step('[pageTwo] reload page and reattach', async () => {
-            return reloadAndReattachAddress(pageTwo, { address })
-          })
-
-        await test.step('[pageTwo] assert room state', async () => {
-          expect(roomSessionTwoAfter.room_session).toBeDefined()
-          expect(roomSessionTwoAfter.call_id).toEqual(
-            allRoomSessions[1].call_id
-          )
-          expect(roomSessionTwoAfter.room_session.members).toHaveLength(4)
-
-          // Expect all members are muted
-          roomSessionTwoAfter.room_session.members.forEach((member) => {
-            expect(member).toBeDefined()
-            expect(member.audio_muted).toBe(true)
-          })
-        })
-
-        // --------------- Attach listeners on all pages ---------------
-        const unmuteListeners = allPages.map(({ page }, i) =>
-          waitForAudioMutedChange(page, allRoomSessions[i].member_id, false)
-        )
-
-        // ----------------- Unmute Audio (pageThree) ---------------------
-        await test.step('[pageThree] unmute all members audio', async () => {
-          await pageThree.evaluate(async () => {
-            // @ts-expect-error
-            const roomObj: FabricRoomSession = window._roomObj
-            await roomObj.audioUnmute({ memberId: 'all' })
-          })
-        })
-
-        await test.step('all pages should receive the memeber.updated events for unmute', async () => {
-          await Promise.all(unmuteListeners)
-        })
-
-        // --------------- Reload and Reattach (pageFour) ----------------
-        const roomSessionFourAfter: CallJoinedEventParams =
-          await test.step('[pageFour] reload page and reattach', async () => {
-            return reloadAndReattachAddress(pageFour, { address })
-          })
-
-        await test.step('[pageFour] assert room state', async () => {
-          expect(roomSessionFourAfter.room_session).toBeDefined()
-          expect(roomSessionFourAfter.call_id).toEqual(
-            allRoomSessions[3].call_id
-          )
-          expect(roomSessionFourAfter.room_session.members).toHaveLength(4)
-
-          // Expect all members are unmuted
-          roomSessionFourAfter.room_session.members.forEach((member) => {
-            expect(member).toBeDefined()
-            expect(member.audio_muted).toBe(false)
-          })
+        // Expect all members are unmuted
+        roomSessionFourAfter.room_session.members.forEach((member) => {
+          expect(member).toBeDefined()
+          expect(member.audio_muted).toBe(false)
         })
       })
     })
   }
+
+  test('Video room: video mute/unmute persists across reload & reattach', async ({
+    createCustomPage,
+    resource,
+  }) => {
+    const { allPages, roomSessions, address } = await joinAllPages(
+      'video',
+      createCustomPage,
+      resource
+    )
+    expect(roomSessions).toHaveLength(4)
+
+    const [pageOne, pageTwo, pageThree, pageFour] = allPages.map((p) => p.page)
+
+    // --------------- Attach listeners on all pages ---------------
+    const muteListeners = allPages.map(({ page }, i) =>
+      waitForMutedChange(page, roomSessions[i].member_id, 'video_muted', true)
+    )
+
+    // ----------------- Mute Video (pageOne) ----------------------
+    await test.step('[pageOne] mute all members video', async () => {
+      await pageOne.evaluate(async () => {
+        // @ts-expect-error
+        await window._roomObj.videoMute({ memberId: 'all' })
+      })
+    })
+
+    await test.step('all pages should receive the memeber.updated events for mute', async () => {
+      await Promise.all(muteListeners)
+    })
+
+    // --------------- Reload and Reattach (pageTwo) ----------------
+    const roomSessionTwoAfter: CallJoinedEventParams =
+      await test.step('[pageTwo] reload page and reattach', async () => {
+        return reloadAndReattachAddress(pageTwo, { address })
+      })
+
+    await test.step('[pageTwo] assert room state', async () => {
+      expect(roomSessionTwoAfter.room_session).toBeDefined()
+      expect(roomSessionTwoAfter.call_id).toEqual(roomSessions[1].call_id)
+      expect(roomSessionTwoAfter.room_session.members).toHaveLength(4)
+
+      // Expect all members are muted
+      roomSessionTwoAfter.room_session.members.forEach((member) => {
+        expect(member).toBeDefined()
+        expect(member.video_muted).toBe(true)
+      })
+    })
+
+    // --------------- Attach listeners on all pages ---------------
+    const unmuteListeners = allPages.map(({ page }, i) =>
+      waitForMutedChange(page, roomSessions[i].member_id, 'video_muted', false)
+    )
+
+    // ----------------- Unmute Video (pageThree) ---------------------
+    await test.step('[pageThree] unmute all members video', async () => {
+      await pageThree.evaluate(async () => {
+        // @ts-expect-error
+        await window._roomObj.videoUnmute({ memberId: 'all' })
+      })
+    })
+
+    await test.step('all pages should receive the memeber.updated events for unmute', async () => {
+      await Promise.all(unmuteListeners)
+    })
+
+    // --------------- Reload and Reattach (pageFour) ----------------
+    const roomSessionFourAfter: CallJoinedEventParams =
+      await test.step('[pageFour] reload page and reattach', async () => {
+        return reloadAndReattachAddress(pageFour, { address })
+      })
+
+    await test.step('[pageFour] assert room state', async () => {
+      expect(roomSessionFourAfter.room_session).toBeDefined()
+      expect(roomSessionFourAfter.call_id).toEqual(roomSessions[3].call_id)
+      expect(roomSessionFourAfter.room_session.members).toHaveLength(4)
+
+      // Expect all members are unmuted
+      roomSessionFourAfter.room_session.members.forEach((member) => {
+        expect(member).toBeDefined()
+        expect(member.video_muted).toBe(false)
+      })
+    })
+  })
 })

--- a/internal/e2e-js/tests/callfabric/muteUnmuteAll.spec.ts
+++ b/internal/e2e-js/tests/callfabric/muteUnmuteAll.spec.ts
@@ -93,19 +93,19 @@ const waitForMutedChange = (
 test.describe('CallFabric - Mute/Unmute All', () => {
   const scenarios = [
     {
-      name: 'Audio-only',
+      name: 'Audio-only room: audio',
       channel: 'audio',
       methods: ['audioMute', 'audioUnmute'],
       field: 'audio_muted',
     },
     {
-      name: 'Video (audio)',
+      name: 'Video room: audio',
       channel: 'video',
       methods: ['audioMute', 'audioUnmute'],
       field: 'audio_muted',
     },
     {
-      name: 'Video (video)',
+      name: 'Video room: video',
       channel: 'video',
       methods: ['videoMute', 'videoUnmute'],
       field: 'video_muted',
@@ -118,7 +118,7 @@ test.describe('CallFabric - Mute/Unmute All', () => {
     methods: [muteFn, unmuteFn],
     field,
   } of scenarios) {
-    test(`${name} room: ${channel} mute/unmute persists across reload & reattach`, async ({
+    test(`${name} should persist mute/unmute of all members across reload and reattach`, async ({
       createCustomPage,
       resource,
     }) => {

--- a/internal/e2e-js/tests/callfabric/muteUnmuteAll.spec.ts
+++ b/internal/e2e-js/tests/callfabric/muteUnmuteAll.spec.ts
@@ -1,0 +1,179 @@
+import { uuid } from '@signalwire/core'
+import { test, expect, Page } from '../../fixtures'
+import {
+  SERVER_URL,
+  createCFClient,
+  dialAddress,
+  expectMCUVisible,
+  reloadAndReattachAddress,
+} from '../../utils'
+import { CallJoinedEventParams, FabricRoomSession } from '@signalwire/js'
+
+const waitForAudioMutedChange = (
+  page: Page,
+  memberId: string,
+  shouldBeMuted: boolean
+): Promise<[boolean, boolean]> => {
+  return page.evaluate(
+    ({ memberId, shouldBeMuted }) => {
+      // @ts-expect-error
+      const roomObj: FabricRoomSession = window._roomObj
+
+      const memberUpdatedEvent = new Promise<boolean>((resolve) => {
+        roomObj.on('member.updated', (e) => {
+          if (
+            e.member.member_id === memberId &&
+            e.member.audio_muted === shouldBeMuted
+          ) {
+            resolve(true)
+          }
+        })
+      })
+
+      const memberAudioMutedEvent = new Promise<boolean>((resolve) => {
+        roomObj.on('member.updated.audioMuted', (e) => {
+          if (
+            e.member.member_id === memberId &&
+            e.member.audio_muted === shouldBeMuted
+          ) {
+            resolve(true)
+          }
+        })
+      })
+
+      return Promise.all([memberUpdatedEvent, memberAudioMutedEvent])
+    },
+    { memberId, shouldBeMuted }
+  )
+}
+
+test.describe('CallFabric - Mute/Unmute All', () => {
+  test('should join a room, mute/unmute all members, reload and reattach with correct states', async ({
+    createCustomPage,
+    resource,
+  }) => {
+    const pageNames = [
+      '[pageOne]',
+      '[pageTwo]',
+      '[pageThree]',
+      '[pageFour]',
+    ] as const
+
+    type NamedPage = { name: (typeof pageNames)[number]; page: Page }
+    const allPages: NamedPage[] = await Promise.all(
+      pageNames.map(async (name) => {
+        const page = await createCustomPage({ name })
+        return { name, page }
+      })
+    )
+
+    await Promise.all(allPages.map(({ page }) => page.goto(SERVER_URL)))
+
+    const roomName = `e2e-video-room-${uuid()}`
+    await resource.createVideoRoomResource(roomName)
+
+    const allRoomSessions: CallJoinedEventParams[] = []
+    for (const { name, page } of allPages) {
+      const roomSession =
+        await test.step(`[${name}] create client and join a room`, async () => {
+          await createCFClient(page)
+
+          const roomSession: CallJoinedEventParams = await dialAddress(page, {
+            address: `/public/${roomName}?channel=video`,
+          })
+
+          expect(roomSession.room_session).toBeDefined()
+          expect(roomSession.room_session.members).toBeDefined()
+
+          await expectMCUVisible(page)
+
+          return roomSession
+        })
+      allRoomSessions.push(roomSession)
+    }
+    expect(allRoomSessions).toHaveLength(4)
+
+    const [
+      { page: pageOne },
+      { page: pageTwo },
+      { page: pageThree },
+      { page: pageFour },
+    ] = allPages
+
+    // --------------- Attach listeners on all pages ---------------
+    const muteListeners = allPages.map(({ page }, i) =>
+      waitForAudioMutedChange(page, allRoomSessions[i].member_id, true)
+    )
+
+    // ----------------- Mute Audio (pageOne) ----------------------
+    await test.step('[pageOne] mute all members audio', async () => {
+      await pageOne.evaluate(async () => {
+        // @ts-expect-error
+        const roomObj: FabricRoomSession = window._roomObj
+        await roomObj.audioMute({ memberId: 'all' })
+      })
+    })
+
+    await test.step('all pages should receive the memeber.updated events for mute', async () => {
+      await Promise.all(muteListeners)
+    })
+
+    // --------------- Reload and Reattach (pageTwo) ----------------
+    const roomSessionTwoAfter: CallJoinedEventParams =
+      await test.step('[pageTwo] reload page and reattach', async () => {
+        return reloadAndReattachAddress(pageTwo, {
+          address: `/public/${roomName}?channel=video`,
+        })
+      })
+
+    await test.step('[pageTwo] assert room state', async () => {
+      expect(roomSessionTwoAfter.room_session).toBeDefined()
+      expect(roomSessionTwoAfter.call_id).toEqual(allRoomSessions[1].call_id)
+      expect(roomSessionTwoAfter.room_session.members).toHaveLength(4)
+
+      // Expect all members are muted
+      roomSessionTwoAfter.room_session.members.forEach((member) => {
+        expect(member).toBeDefined()
+        expect(member.audio_muted).toBe(true)
+      })
+    })
+
+    // --------------- Attach listeners on all pages ---------------
+    const unmuteListeners = allPages.map(({ page }, i) =>
+      waitForAudioMutedChange(page, allRoomSessions[i].member_id, false)
+    )
+
+    // ----------------- Unmute Audio (pageThree) ---------------------
+    await test.step('[pageThree] unmute all members audio', async () => {
+      await pageThree.evaluate(async () => {
+        // @ts-expect-error
+        const roomObj: FabricRoomSession = window._roomObj
+        await roomObj.audioUnmute({ memberId: 'all' })
+      })
+    })
+
+    await test.step('all pages should receive the memeber.updated events for unmute', async () => {
+      await Promise.all(unmuteListeners)
+    })
+
+    // --------------- Reload and Reattach (pageFour) ----------------
+    const roomSessionFourAfter: CallJoinedEventParams =
+      await test.step('[pageFour] reload page and reattach', async () => {
+        return reloadAndReattachAddress(pageFour, {
+          address: `/public/${roomName}?channel=video`,
+        })
+      })
+
+    await test.step('[pageFour] assert room state', async () => {
+      expect(roomSessionFourAfter.room_session).toBeDefined()
+      expect(roomSessionFourAfter.call_id).toEqual(allRoomSessions[3].call_id)
+      expect(roomSessionFourAfter.room_session.members).toHaveLength(4)
+
+      // Expect all members are unmuted
+      roomSessionFourAfter.room_session.members.forEach((member) => {
+        expect(member).toBeDefined()
+        expect(member.audio_muted).toBe(false)
+      })
+    })
+  })
+})

--- a/internal/e2e-js/tests/callfabric/muteUnmuteAll.spec.ts
+++ b/internal/e2e-js/tests/callfabric/muteUnmuteAll.spec.ts
@@ -48,7 +48,7 @@ const waitForAudioMutedChange = (
 }
 
 test.describe('CallFabric - Mute/Unmute All', () => {
-  test('should join a room, mute/unmute all members, reload and reattach with correct states', async ({
+  test('should join a room, mute/unmute all members audio in a video room, reload and reattach with correct states', async ({
     createCustomPage,
     resource,
   }) => {
@@ -71,6 +71,7 @@ test.describe('CallFabric - Mute/Unmute All', () => {
 
     const roomName = `e2e-video-room-${uuid()}`
     await resource.createVideoRoomResource(roomName)
+    const address = `/public/${roomName}?channel=audio`
 
     const allRoomSessions: CallJoinedEventParams[] = []
     for (const { name, page } of allPages) {
@@ -79,7 +80,7 @@ test.describe('CallFabric - Mute/Unmute All', () => {
           await createCFClient(page)
 
           const roomSession: CallJoinedEventParams = await dialAddress(page, {
-            address: `/public/${roomName}?channel=video`,
+            address,
           })
 
           expect(roomSession.room_session).toBeDefined()
@@ -121,9 +122,7 @@ test.describe('CallFabric - Mute/Unmute All', () => {
     // --------------- Reload and Reattach (pageTwo) ----------------
     const roomSessionTwoAfter: CallJoinedEventParams =
       await test.step('[pageTwo] reload page and reattach', async () => {
-        return reloadAndReattachAddress(pageTwo, {
-          address: `/public/${roomName}?channel=video`,
-        })
+        return reloadAndReattachAddress(pageTwo, { address })
       })
 
     await test.step('[pageTwo] assert room state', async () => {
@@ -159,9 +158,131 @@ test.describe('CallFabric - Mute/Unmute All', () => {
     // --------------- Reload and Reattach (pageFour) ----------------
     const roomSessionFourAfter: CallJoinedEventParams =
       await test.step('[pageFour] reload page and reattach', async () => {
-        return reloadAndReattachAddress(pageFour, {
-          address: `/public/${roomName}?channel=video`,
+        return reloadAndReattachAddress(pageFour, { address })
+      })
+
+    await test.step('[pageFour] assert room state', async () => {
+      expect(roomSessionFourAfter.room_session).toBeDefined()
+      expect(roomSessionFourAfter.call_id).toEqual(allRoomSessions[3].call_id)
+      expect(roomSessionFourAfter.room_session.members).toHaveLength(4)
+
+      // Expect all members are unmuted
+      roomSessionFourAfter.room_session.members.forEach((member) => {
+        expect(member).toBeDefined()
+        expect(member.audio_muted).toBe(false)
+      })
+    })
+  })
+
+  test('should join a room, mute/unmute all members audio in an audio-only room, reload and reattach with correct states', async ({
+    createCustomPage,
+    resource,
+  }) => {
+    const pageNames = [
+      '[pageOne]',
+      '[pageTwo]',
+      '[pageThree]',
+      '[pageFour]',
+    ] as const
+
+    type NamedPage = { name: (typeof pageNames)[number]; page: Page }
+    const allPages: NamedPage[] = await Promise.all(
+      pageNames.map(async (name) => {
+        const page = await createCustomPage({ name })
+        return { name, page }
+      })
+    )
+
+    await Promise.all(allPages.map(({ page }) => page.goto(SERVER_URL)))
+
+    const roomName = `e2e-audio-room-${uuid()}`
+    await resource.createVideoRoomResource(roomName)
+    const address = `/public/${roomName}?channel=audio`
+
+    const allRoomSessions: CallJoinedEventParams[] = []
+    for (const { name, page } of allPages) {
+      const roomSession =
+        await test.step(`[${name}] create client and join a room`, async () => {
+          await createCFClient(page)
+
+          const roomSession: CallJoinedEventParams = await dialAddress(page, {
+            address,
+          })
+
+          expect(roomSession.room_session).toBeDefined()
+          expect(roomSession.room_session.members).toBeDefined()
+
+          return roomSession
         })
+      allRoomSessions.push(roomSession)
+    }
+    expect(allRoomSessions).toHaveLength(4)
+
+    const [
+      { page: pageOne },
+      { page: pageTwo },
+      { page: pageThree },
+      { page: pageFour },
+    ] = allPages
+
+    // --------------- Attach listeners on all pages ---------------
+    const muteListeners = allPages.map(({ page }, i) =>
+      waitForAudioMutedChange(page, allRoomSessions[i].member_id, true)
+    )
+
+    // ----------------- Mute Audio (pageOne) ----------------------
+    await test.step('[pageOne] mute all members audio', async () => {
+      await pageOne.evaluate(async () => {
+        // @ts-expect-error
+        const roomObj: FabricRoomSession = window._roomObj
+        await roomObj.audioMute({ memberId: 'all' })
+      })
+    })
+
+    await test.step('all pages should receive the memeber.updated events for mute', async () => {
+      await Promise.all(muteListeners)
+    })
+
+    // --------------- Reload and Reattach (pageTwo) ----------------
+    const roomSessionTwoAfter: CallJoinedEventParams =
+      await test.step('[pageTwo] reload page and reattach', async () => {
+        return reloadAndReattachAddress(pageTwo, { address })
+      })
+
+    await test.step('[pageTwo] assert room state', async () => {
+      expect(roomSessionTwoAfter.room_session).toBeDefined()
+      expect(roomSessionTwoAfter.call_id).toEqual(allRoomSessions[1].call_id)
+      expect(roomSessionTwoAfter.room_session.members).toHaveLength(4)
+
+      // Expect all members are muted
+      roomSessionTwoAfter.room_session.members.forEach((member) => {
+        expect(member).toBeDefined()
+        expect(member.audio_muted).toBe(true)
+      })
+    })
+
+    // --------------- Attach listeners on all pages ---------------
+    const unmuteListeners = allPages.map(({ page }, i) =>
+      waitForAudioMutedChange(page, allRoomSessions[i].member_id, false)
+    )
+
+    // ----------------- Unmute Audio (pageThree) ---------------------
+    await test.step('[pageThree] unmute all members audio', async () => {
+      await pageThree.evaluate(async () => {
+        // @ts-expect-error
+        const roomObj: FabricRoomSession = window._roomObj
+        await roomObj.audioUnmute({ memberId: 'all' })
+      })
+    })
+
+    await test.step('all pages should receive the memeber.updated events for unmute', async () => {
+      await Promise.all(unmuteListeners)
+    })
+
+    // --------------- Reload and Reattach (pageFour) ----------------
+    const roomSessionFourAfter: CallJoinedEventParams =
+      await test.step('[pageFour] reload page and reattach', async () => {
+        return reloadAndReattachAddress(pageFour, { address })
       })
 
     await test.step('[pageFour] assert room state', async () => {

--- a/internal/e2e-js/utils.ts
+++ b/internal/e2e-js/utils.ts
@@ -158,7 +158,7 @@ export const createTestSATToken = async () => {
 }
 
 interface GuestSATTokenRequest {
-  allowed_addresses: string[];
+  allowed_addresses: string[]
 }
 export const createGuestSATToken = async (bodyData: GuestSATTokenRequest) => {
   const response = await fetch(
@@ -190,7 +190,6 @@ export const getResourceAddresses = async (resource_id: string) => {
   const data = await response.json()
   return data
 }
-
 
 interface CreateTestCRTOptions {
   ttl: number
@@ -509,8 +508,8 @@ export const createCFClient = async (
   page: Page,
   params?: CreateCFClientParams
 ) => {
-  const sat = await createTestSATToken();
-  return createCFClientWithToken(page, sat, params);
+  const sat = await createTestSATToken()
+  return createCFClientWithToken(page, sat, params)
 }
 
 export const createGuestCFClient = async (
@@ -518,8 +517,8 @@ export const createGuestCFClient = async (
   bodyData: GuestSATTokenRequest,
   params?: CreateCFClientParams
 ) => {
-  const sat = await createGuestSATToken(bodyData);
-  return createCFClientWithToken(page, sat, params);
+  const sat = await createGuestSATToken(bodyData)
+  return createCFClientWithToken(page, sat, params)
 }
 
 const createCFClientWithToken = async (
@@ -563,7 +562,6 @@ const createCFClientWithToken = async (
         },
       }
 
-      // @ts-expect-error
       const SignalWire = window._SWJS.SignalWire
       const client: SignalWireContract = await SignalWire({
         host: options.RELAY_HOST,
@@ -572,7 +570,6 @@ const createCFClientWithToken = async (
         ...(options.attachSagaMonitor && { sagaMonitor }),
       })
 
-      // @ts-expect-error
       window._client = client
       return client
     },
@@ -613,8 +610,12 @@ export const dialAddress = (page: Page, params: DialAddressParams) => {
       shouldWaitForJoin,
     }) => {
       return new Promise<any>(async (resolve, _reject) => {
-        // @ts-expect-error
-        const client: SignalWireContract = window._client
+        const client = window._client
+
+        if (!client) {
+          console.error('Client not defined!')
+          return
+        }
 
         const dialer = reattach ? client.reattach : client.dial
 
@@ -651,6 +652,16 @@ export const dialAddress = (page: Page, params: DialAddressParams) => {
       shouldWaitForJoin,
     }
   )
+}
+
+export const reloadAndReattachAddress = async (
+  page: Page,
+  params: Omit<DialAddressParams, 'reattach'>
+) => {
+  await page.reload({ waitUntil: 'domcontentloaded' })
+  await createCFClient(page)
+
+  return dialAddress(page, { ...params, reattach: true })
 }
 
 export const disconnectClient = (page: Page) => {
@@ -1403,7 +1414,7 @@ export class MockWebhookServer extends EventEmitter {
   constructor() {
     super()
     this.app = express()
-    this.app.use(express.urlencoded({ extended: true }));
+    this.app.use(express.urlencoded({ extended: true }))
     const self = this
     this.app.all('/', (req: Request, res: Response) => {
       self.emit('request', req)
@@ -1415,7 +1426,7 @@ export class MockWebhookServer extends EventEmitter {
   listen(port: number = 18989, startTunnel: boolean = false) {
     return new Promise<string>((resolve) => {
       this.server = this.app.listen(port, (err?: Error) => {
-        if(err) {
+        if (err) {
           console.error('Error Starting MockWebhookServer: ', err)
           process.exit(5)
         }
@@ -1424,7 +1435,7 @@ export class MockWebhookServer extends EventEmitter {
           return
         }
       })
-  
+
       if (startTunnel) {
         const MAX_RETRIES = 3
         const tunnel = (attempt = 0) => {
@@ -1436,13 +1447,13 @@ export class MockWebhookServer extends EventEmitter {
               'proxy',
               '--headless',
               '--insecure',
-              `${port}`
+              `${port}`,
             ])
             this.zrokProcess.on('error', (err) => {
-              console.error('zrok process error event: ', err);
+              console.error('zrok process error event: ', err)
             })
             this.zrokProcess.stdout.on('data', (data) => {
-              console.log(`zrok processs stdout: ${data}`);
+              console.log(`zrok processs stdout: ${data}`)
             })
             this.zrokProcess.stderr.on('data', (data) => {
               const dataStr = data.toString('utf-8')
@@ -1451,7 +1462,12 @@ export class MockWebhookServer extends EventEmitter {
                 const logObj = JSON.parse(dataStr)
                 if (logObj.level == 'info') {
                   console.log(`zrok process stdout: ${data}`)
-                  if (logObj.msg && logObj.msg.startsWith('access your zrok share at the following endpoints:')) {
+                  if (
+                    logObj.msg &&
+                    logObj.msg.startsWith(
+                      'access your zrok share at the following endpoints:'
+                    )
+                  ) {
                     const tunnelUrl = logObj.msg.split('\n')[1].trim()
                     resolve(tunnelUrl as string)
                   }
@@ -1462,23 +1478,23 @@ export class MockWebhookServer extends EventEmitter {
                 if (dataStr.startsWith('[ERROR]: unable to create share')) {
                   console.error('Error Starting Zrok Share: ', dataStr)
                   if (attempt < MAX_RETRIES) {
-                    console.log(`Retrying (attempt: ${attempt+1} `)
-                    tunnel(attempt+1)
+                    console.log(`Retrying (attempt: ${attempt + 1} `)
+                    tunnel(attempt + 1)
                   } else {
                     process.exit(5)
                   }
                 }
               }
             })
-          
+
             this.zrokProcess.on('close', (code) => {
-              console.log(`zrok process exited with code ${code}`);
+              console.log(`zrok process exited with code ${code}`)
             })
           } catch (err) {
             console.error('Error Starting Zrok Share: ', err)
             if (attempt < MAX_RETRIES) {
-              console.log(`Retrying (attempt: ${attempt+1} `)
-              tunnel(attempt+1)
+              console.log(`Retrying (attempt: ${attempt + 1} `)
+              tunnel(attempt + 1)
             } else {
               process.exit(5)
             }
@@ -1505,7 +1521,6 @@ export class MockWebhookServer extends EventEmitter {
     this.zrokProcess.kill('SIGKILL')
   }
 }
-
 
 // #endregion
 

--- a/packages/core/src/types/fabricRoomSession.ts
+++ b/packages/core/src/types/fabricRoomSession.ts
@@ -498,7 +498,7 @@ export interface FabricRoomSessionContract {
    * });
    * ```
    */
-  setAudioFlags(params: SetAudioFlagsParams): Rooms.SetRaisedHand
+  setAudioFlags(params: SetAudioFlagsParams): Promise<void>
 }
 
 /**

--- a/packages/js/src/fabric/FabricRoomSession.ts
+++ b/packages/js/src/fabric/FabricRoomSession.ts
@@ -70,7 +70,7 @@ export class FabricRoomSessionConnection
     params.dialogParams.reattaching = this.options.attach || this.resuming
     return params
   }
-  
+
   set currentLayoutEvent(event: FabricLayoutChangedEventParams) {
     this._currentLayoutEvent = event
   }
@@ -152,10 +152,18 @@ export class FabricRoomSessionConnection
   ) {
     const { method, channel, memberId, extraParams = {} } = params
 
-    const targetMember = memberId
-      ? this.instanceMap.get<FabricRoomSessionMember>(memberId)
-      : this.member
-    if (!targetMember) throw new Error('No target param found to execute')
+    const targetMember =
+      !memberId || memberId === 'all'
+        ? this.member
+        : this.instanceMap.get<FabricRoomSessionMember>(memberId)
+
+    if (!targetMember) {
+      throw new Error(
+        memberId && memberId !== 'all'
+          ? `Member ${memberId} not found`
+          : 'No target member available'
+      )
+    }
 
     return this.execute<InputType, OutputType, ParamsType>(
       {
@@ -168,7 +176,7 @@ export class FabricRoomSessionConnection
             node_id: this.selfMember?.nodeId,
           },
           target: {
-            member_id: targetMember.id,
+            member_id: memberId === 'all' ? memberId : targetMember.id,
             call_id: targetMember.callId,
             node_id: targetMember.nodeId,
           },

--- a/packages/js/src/fabric/FabricRoomSession.ts
+++ b/packages/js/src/fabric/FabricRoomSession.ts
@@ -135,11 +135,11 @@ export class FabricRoomSessionConnection
     if (this.options.attach) {
       this.options.prevCallId =
         getStorage()?.getItem(PREVIOUS_CALLID_STORAGE_KEY) ?? undefined
+      this.logger.debug(
+        `Tying to reattach to previuos call? ${!!this.options
+          .prevCallId} - prevCallId: ${this.options.prevCallId}`
+      )
     }
-    this.logger.debug(
-      `Tying to reattach to previuos call? ${!!this.options
-        .prevCallId} - prevCallId: ${this.options.prevCallId}`
-    )
 
     return super.invite<FabricRoomSession>()
   }

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -127,6 +127,7 @@ export type {
   ConversationMessageEvent,
   ConversationEventParams,
   ConversationEvent,
+  SetAudioFlagsParams,
 } from '@signalwire/core'
 
 export type {


### PR DESCRIPTION
# Description

- Allow developers to mute/unmute all participants in the call (both audio-only and video calls). 
- Include E2E Test for audio mute/unmute in an audio-only call with reattach.
- Include E2E Test for audio mute/unmute in a video room call with reattach.
- Include E2E Test for video mute/unmute in a video room call with reattach.

## Type of change

- [ ] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

```ts
// Mute all members’ audio
await audioMute({ memberId: "all" })

// Unmute all members’ audio
await audioUnmute({ memberId: "all" })

// Mute all members’ video
await videoMute({ memberId: "all" })

// Unmute all members’ video
await videoUnmute({ memberId: "all" })
```