### PR TITLE
Fix Prettify

### DIFF
--- a/.changeset/fancy-dancers-dig.md
+++ b/.changeset/fancy-dancers-dig.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': patch
+---
+
+Fix Prettify preserving callable objects types

--- a/packages/core/src/types/utils.ts
+++ b/packages/core/src/types/utils.ts
@@ -135,12 +135,14 @@ export type Promisify<T> = {
  * Flattens object types for better IDE display while preserving function types
  */
 export type Prettify<T> = T extends (...args: any[]) => any
-? T  // Preserve function types as-is
-: T extends object
-? {
-    [K in keyof T]: T[K]
-} & {}
-: T
+  ? T  // Preserve pure function types as-is
+  : T extends { (...args: any[]): any } // Check for callable objects
+  ? T  // Preserve callable objects (functions with properties)
+  : T extends object
+  ? {
+      [K in keyof T]: T[K]
+    } & {}
+  : T
 
 /**
  * Construct a type that requires at least one property from `Keys` of `T`.

--- a/packages/core/src/types/utils.ts
+++ b/packages/core/src/types/utils.ts
@@ -134,10 +134,8 @@ export type Promisify<T> = {
 /*
  * Flattens object types for better IDE display while preserving function types
  */
-export type Prettify<T> = T extends (...args: any[]) => any
-  ? T  // Preserve pure function types as-is
-  : T extends { (...args: any[]): any } // Check for callable objects
-  ? T  // Preserve callable objects (functions with properties)
+export type Prettify<T> = T extends { (...args: any[]): any }
+  ? T  // Preserve callable objects (functions with properties, overloads, etc.)
   : T extends object
   ? {
       [K in keyof T]: T[K]


### PR DESCRIPTION
# Description

Makes Prettify type function to preserve the callable objects' types to fix:

<img width="1034" height="707" alt="Status_and_call_ts__Working_Tree___call_ts__—_puc-client" src="https://github.com/user-attachments/assets/2669b6df-d1a3-4a91-8300-883e2391a80c" />

## Type of change

- [ ] Internal refactoring
- [x] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
