### PR TITLE
Fix e2e util DialAddress default params and incorrect assertions in `videoRoom.spec.ts`

### DIFF
--- a/internal/e2e-client/tests/callfabric/videoRoom.spec.ts
+++ b/internal/e2e-client/tests/callfabric/videoRoom.spec.ts
@@ -344,9 +344,6 @@ test.describe('CallCall VideoRoom', () => {
     // --------------- Screenshare ---------------
     await test.step('screen share', async () => {
       const screenMemberJoined = expectPageEvalToPass(page, {
-        assertionFn: (result) => {
-          expect(result, 'screen joined result resolved').toBe(true)
-        },
         evaluateArgs: { callObj },
         evaluateFn: async (params) => {
           return new Promise<string>((resolve) => {
@@ -356,6 +353,10 @@ test.describe('CallCall VideoRoom', () => {
               }
             })
           })
+        },
+        assertionFn: (result) => {
+          // should be a string uuid type
+          expect(result, 'screen joined result resolved').toBeDefined()
         },
         message: 'expect screen joined result',
       })

--- a/internal/e2e-client/tests/callfabric/videoRoom.spec.ts
+++ b/internal/e2e-client/tests/callfabric/videoRoom.spec.ts
@@ -105,9 +105,6 @@ test.describe('CallCall VideoRoom', () => {
     // --------------- Muting Audio (self) ---------------
     await test.step('muting audio (self)', async () => {
       const memberUpdatedMutedEvent = expectPageEvalToPass(page, {
-        assertionFn: (result) => {
-          expect(result, 'member updated muted event resolved').toBe(true)
-        },
         evaluateArgs: { callObj, callSession },
         evaluateFn: (params) => {
           return new Promise<boolean>((resolve) => {
@@ -121,13 +118,13 @@ test.describe('CallCall VideoRoom', () => {
             })
           })
         },
+        assertionFn: (result) => {
+          expect(result, 'member updated muted event resolved').toBe(true)
+        },
         message: 'expect member updated muted event',
       })
 
       const memberUpdatedMuted = expectPageEvalToPass(page, {
-        assertionFn: (result) => {
-          expect(result, 'member updated muted resolved').toBe(true)
-        },
         evaluateArgs: { callObj, callSession },
         evaluateFn: (params) => {
           return new Promise<boolean>((resolve) => {
@@ -141,6 +138,9 @@ test.describe('CallCall VideoRoom', () => {
               }
             })
           })
+        },
+        assertionFn: (result) => {
+          expect(result, 'member updated muted resolved').toBe(true)
         },
         message: 'expect member updated muted',
       })
@@ -158,9 +158,6 @@ test.describe('CallCall VideoRoom', () => {
     // --------------- Unmuting Audio (self) ---------------
     await test.step('unmuting audio (self)', async () => {
       const memberUpdatedUnmutedEvent = expectPageEvalToPass(page, {
-        assertionFn: (result) => {
-          expect(result, 'member updated unmuted event resolved').toBe(true)
-        },
         evaluateArgs: { callObj, callSession },
         evaluateFn: (params) => {
           return new Promise<boolean>((resolve) => {
@@ -174,13 +171,13 @@ test.describe('CallCall VideoRoom', () => {
             })
           })
         },
+        assertionFn: (result) => {
+          expect(result, 'member updated unmuted event resolved').toBe(true)
+        },
         message: 'expect member updated unmuted event',
       })
 
       const memberUpdatedUnmuted = expectPageEvalToPass(page, {
-        assertionFn: (result) => {
-          expect(result, 'member updated unmuted resolved').toBe(true)
-        },
         evaluateArgs: { callObj, callSession },
         evaluateFn: (params) => {
           return new Promise<boolean>((resolve) => {
@@ -195,17 +192,20 @@ test.describe('CallCall VideoRoom', () => {
             })
           })
         },
+        assertionFn: (result) => {
+          expect(result, 'member updated unmuted resolved').toBe(true)
+        },
         message: 'expect member updated unmuted',
       })
 
       const audioUnmuteSelf = expectPageEvalToPass(page, {
-        assertionFn: (result) => {
-          expect(result, 'member video updated muted event resolved').toBe(true)
-        },
         evaluateArgs: { callObj },
         evaluateFn: async (params) => {
           await params.callObj.audioUnmute()
           return true
+        },
+        assertionFn: (result) => {
+          expect(result, 'member video updated muted event resolved').toBe(true)
         },
         message: 'expect audio unmute self',
       })
@@ -217,9 +217,6 @@ test.describe('CallCall VideoRoom', () => {
     // --------------- Muting Video (self) ---------------
     await test.step('muting video (self)', async () => {
       const memberVideoUpdatedMutedEvent = expectPageEvalToPass(page, {
-        assertionFn: (result) => {
-          expect(result, 'member video updated muted event resolved').toBe(true)
-        },
         evaluateArgs: { callObj, callSession },
         evaluateFn: (params) => {
           return new Promise<boolean>((resolve) => {
@@ -234,15 +231,13 @@ test.describe('CallCall VideoRoom', () => {
             })
           })
         },
+        assertionFn: (result) => {
+          expect(result, 'member video updated muted event resolved').toBe(true)
+        },
         message: 'expect member video updated muted event',
       })
 
       const memberVideoUpdatedMuted = expectPageEvalToPass(page, {
-        assertionFn: (result) => {
-          expect(result, 'member video updated unmuted event resolved').toBe(
-            true
-          )
-        },
         evaluateArgs: { callObj, callSession },
         evaluateFn: (params) => {
           return new Promise<boolean>((resolve) => {
@@ -259,16 +254,21 @@ test.describe('CallCall VideoRoom', () => {
             })
           })
         },
+        assertionFn: (result) => {
+          expect(result, 'member video updated unmuted event resolved').toBe(
+            true
+          )
+        },
         message: 'expect member video updated muted',
       })
       const videoMuteSelf = expectPageEvalToPass(page, {
-        assertionFn: (result) => {
-          expect(result, 'video mute self resolved').toBe(true)
-        },
         evaluateArgs: { callObj },
         evaluateFn: async (params) => {
           await params.callObj.videoMute()
           return true
+        },
+        assertionFn: (result) => {
+          expect(result, 'video mute self resolved').toBe(true)
         },
         message: 'expect video mute self',
       })
@@ -281,9 +281,6 @@ test.describe('CallCall VideoRoom', () => {
 
     await test.step('unmuting video (self)  ', async () => {
       const memberVideoUpdatedUnmutedEvent = expectPageEvalToPass(page, {
-        assertionFn: (result) => {
-          expect(result, 'member video updated unmuted resolved').toBe(true)
-        },
         evaluateArgs: { callObj, callSession },
         evaluateFn: (params) => {
           return new Promise<boolean>((resolve) => {
@@ -298,13 +295,13 @@ test.describe('CallCall VideoRoom', () => {
             })
           })
         },
+        assertionFn: (result) => {
+          expect(result, 'member video updated unmuted resolved').toBe(true)
+        },
         message: 'expect member video updated unmuted event',
       })
 
       const memberVideoUpdatedUnmuted = expectPageEvalToPass(page, {
-        assertionFn: (result) => {
-          expect(result, 'video unmute self resolved').toBe(true)
-        },
         evaluateArgs: { callObj, callSession },
         evaluateFn: async (params) => {
           return new Promise<boolean>((resolve) => {
@@ -321,17 +318,20 @@ test.describe('CallCall VideoRoom', () => {
             })
           })
         },
+        assertionFn: (result) => {
+          expect(result, 'video unmute self resolved').toBe(true)
+        },
         message: 'expect member video updated unmuted',
       })
 
       const videoUnmuteSelf = expectPageEvalToPass(page, {
-        assertionFn: (result) => {
-          expect(result, 'video unmute self resolved').toBe(true)
-        },
         evaluateArgs: { callObj },
         evaluateFn: async (params) => {
           await params.callObj.videoUnmute()
           return true
+        },
+        assertionFn: (result) => {
+          expect(result, 'video unmute self resolved').toBe(true)
         },
         message: 'expect video unmute self',
       })
@@ -376,22 +376,19 @@ test.describe('CallCall VideoRoom', () => {
 
       // --------------- Check Screen Share ID ---------------
       await expectPageEvalToPass(page, {
-        assertionFn: (result) => {
-          expect(result, 'screen left resolved').toBe(true)
-        },
         evaluateArgs: { screenShareObj, screenMemberId },
         evaluateFn: (params) => {
           return new Promise<boolean>((resolve) => {
             resolve(params.screenMemberId === params.screenShareObj.memberId)
           })
         },
+        assertionFn: (result) => {
+          expect(result, 'screen left resolved').toBe(true)
+        },
         message: 'expect screen share id check',
       })
 
       const screenMemberLeft = expectPageEvalToPass(page, {
-        assertionFn: (result) => {
-          expect(result, 'screen member left resolved').toBe(true)
-        },
         evaluateArgs: { callObj, screenMemberId },
         evaluateFn: async (params) => {
           return new Promise<boolean>((resolve) => {
@@ -405,30 +402,33 @@ test.describe('CallCall VideoRoom', () => {
             })
           })
         },
+        assertionFn: (result) => {
+          expect(result, 'screen member left resolved').toBe(true)
+        },
         message: 'expect screen left',
       })
 
       const screenRoomLeft = expectPageEvalToPass(page, {
-        assertionFn: (result) => {
-          expect(result, 'screen room left resolved').toBe(true)
-        },
         evaluateArgs: { screenShareObj },
         evaluateFn: (params) => {
           return new Promise<boolean>((resolve) => {
             params.screenShareObj.on('room.left', () => resolve(true))
           })
         },
+        assertionFn: (result) => {
+          expect(result, 'screen room left resolved').toBe(true)
+        },
         message: 'expect screen room left',
       })
 
       const screenShareObjCallLeave = expectPageEvalToPass(page, {
-        assertionFn: (result) => {
-          expect(result, 'screen share obj left resolved').toBe(true)
-        },
         evaluateArgs: { screenShareObj },
         evaluateFn: async (params) => {
           await params.screenShareObj.leave()
           return true
+        },
+        assertionFn: (result) => {
+          expect(result, 'screen share obj left resolved').toBe(true)
         },
         message: 'expect screen share obj left',
       })
@@ -443,9 +443,6 @@ test.describe('CallCall VideoRoom', () => {
     // --------------- Room lock/unlock ---------------
     await test.step('room lock', async () => {
       const roomUpdatedLocked = expectPageEvalToPass(page, {
-        assertionFn: (result) => {
-          expect(result, 'room updated locked resolved').toBe(true)
-        },
         evaluateArgs: { callObj },
         evaluateFn: async (params) => {
           return new Promise<boolean>((resolve) => {
@@ -456,17 +453,20 @@ test.describe('CallCall VideoRoom', () => {
             })
           })
         },
+        assertionFn: (result) => {
+          expect(result, 'room updated locked resolved').toBe(true)
+        },
         message: 'expect room updated locked',
       })
 
       const roomLock = expectPageEvalToPass(page, {
-        assertionFn: (result) => {
-          expect(result, 'room updated unlocked resolved').toBe(true)
-        },
         evaluateArgs: { callObj },
         evaluateFn: async (params) => {
           await params.callObj.lock()
           return true
+        },
+        assertionFn: (result) => {
+          expect(result, 'room updated unlocked resolved').toBe(true)
         },
         message: 'expect room lock',
       })
@@ -477,9 +477,6 @@ test.describe('CallCall VideoRoom', () => {
 
     await test.step('room unlock', async () => {
       const roomUpdatedUnlocked = expectPageEvalToPass(page, {
-        assertionFn: (result) => {
-          expect(result, 'room updated unlocked resolved').toBe(true)
-        },
         evaluateArgs: { callObj },
         evaluateFn: async (params) => {
           return new Promise<boolean>((resolve) => {
@@ -490,17 +487,20 @@ test.describe('CallCall VideoRoom', () => {
             })
           })
         },
+        assertionFn: (result) => {
+          expect(result, 'room updated unlocked resolved').toBe(true)
+        },
         message: 'expect room updated unlocked',
       })
 
       const roomUnlock = expectPageEvalToPass(page, {
-        assertionFn: (result) => {
-          expect(result, 'room updated unlocked resolved').toBe(true)
-        },
         evaluateArgs: { callObj },
         evaluateFn: async (params) => {
           await params.callObj.unlock()
           return true
+        },
+        assertionFn: (result) => {
+          expect(result, 'room updated unlocked resolved').toBe(true)
         },
         message: 'expect room unlock',
       })
@@ -616,12 +616,6 @@ test.describe('CallCall VideoRoom', () => {
 
     // Dial an address and join a video room using expectPageEvalToPass
     await expectPageEvalToPass(page, {
-      assertionFn: (result) => {
-        expect(
-          result.success,
-          'call session should return success as false'
-        ).toBe(false)
-      },
       evaluateFn: async () => {
         try {
           const client = window._client
@@ -642,6 +636,12 @@ test.describe('CallCall VideoRoom', () => {
         } catch (error) {
           return { success: false, error }
         }
+      },
+      assertionFn: (result) => {
+        expect(
+          result.success,
+          'call session should return success as false'
+        ).toBe(false)
       },
       message: 'expect call session to fail on invalid address',
     })

--- a/internal/e2e-client/tests/callfabric/videoRoom.spec.ts
+++ b/internal/e2e-client/tests/callfabric/videoRoom.spec.ts
@@ -86,14 +86,14 @@ test.describe('CallCall VideoRoom', () => {
         callObj.getProperty('leave'),
         'call object leave should be defined'
       ).toBeDefined()
-      expect(callSession).toHaveProperty(
-        'room_session',
+      expect(
+        callSession,
         'call session room session should be defined'
-      )
-      expect(callSession).toHaveProperty(
-        'member_id',
+      ).toHaveProperty('room_session')
+      expect(
+        callSession,
         'call session member id should be defined'
-      )
+      ).toHaveProperty('member_id')
       expect(page.goto, 'page goto should be defined').toBeDefined()
       expect(page.evaluate, 'page evaluate should be defined').toBeDefined()
       expect(

--- a/internal/e2e-client/utils.ts
+++ b/internal/e2e-client/utils.ts
@@ -397,9 +397,6 @@ const createCFClientWithToken = async (
   const { attachSagaMonitor = false } = params || {}
 
   const swClient = (await expectPageEvalToPass(page, {
-    assertionFn: (client) => {
-      expect(client, 'SignalWire client should be defined').toBeDefined()
-    },
     evaluateArgs: {
       RELAY_HOST: process.env.RELAY_HOST,
       API_TOKEN: sat,
@@ -454,6 +451,9 @@ const createCFClientWithToken = async (
       window._client = client
       return client
     },
+    assertionFn: (client) => {
+      expect(client, 'SignalWire client should be defined').toBeDefined()
+    },
     message: 'expect SignalWire client to be created',
   })) as SignalWireContract
 
@@ -498,9 +498,6 @@ export const dialAddress = <TReturn = any>(
   }
 
   return expectPageEvalToPass<EvaluateArgs, TReturn>(page, {
-    assertionFn: (result) => {
-      expect(result, 'dialAddress result should be defined').toBeDefined()
-    },
     evaluateArgs: {
       address: mergedParams.address,
       dialOptions: JSON.stringify(mergedParams.dialOptions),
@@ -549,6 +546,9 @@ export const dialAddress = <TReturn = any>(
           resolve(call)
         }
       })
+    },
+    assertionFn: (result) => {
+      expect(result, 'dialAddress result should be defined').toBeDefined()
     },
     message: 'expect dialAddress to succeed',
   })
@@ -1743,9 +1743,6 @@ export const expectCFFinalEvents = (
 
 export const expectLayoutChanged = async (page: Page, layoutName: string) => {
   return await expectPageEvalToPass(page, {
-    assertionFn: (result) => {
-      expect(result, 'expect layout changed result').toBe(true)
-    },
     evaluateArgs: { layoutName },
     evaluateFn: (params) => {
       return new Promise<boolean>((resolve) => {
@@ -1759,6 +1756,9 @@ export const expectLayoutChanged = async (page: Page, layoutName: string) => {
           }
         })
       })
+    },
+    assertionFn: (result) => {
+      expect(result, 'expect layout changed result').toBe(true)
     },
     message: 'expect layout changed result',
   })
@@ -1811,9 +1811,6 @@ export const expectInteractivityMode = async (
 
 export const setLayoutOnPage = async (page: Page, layoutName: string) => {
   const layoutChanged = await expectPageEvalToPass(page, {
-    assertionFn: (result) => {
-      expect(result, 'layout changed result should be true').toBe(true)
-    },
     evaluateArgs: { layoutName },
     evaluateFn: async (params) => {
       const callObj = window._callObj
@@ -1822,6 +1819,9 @@ export const setLayoutOnPage = async (page: Page, layoutName: string) => {
       }
       await callObj.setLayout({ name: params.layoutName })
       return true
+    },
+    assertionFn: (result) => {
+      expect(result, 'layout changed result should be true').toBe(true)
     },
     message: 'expect set layout',
   })

--- a/internal/e2e-client/utils.ts
+++ b/internal/e2e-client/utils.ts
@@ -480,6 +480,19 @@ export const dialAddress = <TReturn = any>(
     shouldWaitForJoin: true,
   }
 ) => {
+  const defaultParams: DialAddressParams = {
+    address: '',
+    dialOptions: {},
+    reattach: false,
+    shouldPassRootElement: true,
+    shouldStartCall: true,
+    shouldWaitForJoin: true,
+  }
+  const mergedParams: DialAddressParams = {
+    ...defaultParams,
+    ...params,
+  }
+
   type EvaluateArgs = Omit<DialAddressParams, 'dialOptions'> & {
     dialOptions: string
   }
@@ -489,8 +502,12 @@ export const dialAddress = <TReturn = any>(
       expect(result, 'dialAddress result should be defined').toBeDefined()
     },
     evaluateArgs: {
-      ...params,
-      dialOptions: JSON.stringify(params.dialOptions),
+      address: mergedParams.address,
+      dialOptions: JSON.stringify(mergedParams.dialOptions),
+      reattach: mergedParams.reattach,
+      shouldPassRootElement: mergedParams.shouldPassRootElement,
+      shouldStartCall: mergedParams.shouldStartCall,
+      shouldWaitForJoin: mergedParams.shouldWaitForJoin,
     },
     evaluateFn: async ({
       address,

--- a/internal/e2e-client/utils.ts
+++ b/internal/e2e-client/utils.ts
@@ -623,8 +623,7 @@ interface GetStatsResult {
 }
 
 export const getStats = async (page: Page): Promise<GetStatsResult> => {
-  let result = {} as GetStatsResult
-  await expectPageEvalToPass(page, {
+  return await expectPageEvalToPass(page, {
     evaluateFn: async () => {
       const callObj = window._callObj
       if (!callObj) {
@@ -756,7 +755,6 @@ export const getStats = async (page: Page): Promise<GetStatsResult> => {
     },
     message: 'expect to get RTP stats',
   })
-  return result
 }
 
 // TODO: This is not used anywhere, remove it?


### PR DESCRIPTION
# Description
- fix `dialAddress()` util default parameters to not be overridden  
- refactor e2e test parameter order when using `expectPageEvalToPass` to ensure correct type inference
- fix for `getStats()` util to return correct value
- fix incorrect args for assertions in `videoRoom.spec.ts` (passing in wrong value at wrong parameter)

## Type of change

- [ ] Internal refactoring
- [x] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
