### PR TITLE
add missing await

### DIFF
--- a/.changeset/better-gifts-cross.md
+++ b/.changeset/better-gifts-cross.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/webrtc': patch
+---
+
+fix missing await in the BaseConnection.unhold  
+

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -1463,7 +1463,7 @@ export class BaseConnection<
       ...this.dialogParams(this.callId),
       action: 'unhold',
     })
-    this.vertoExecute<VertoModifyResponse>({
+    await this.vertoExecute<VertoModifyResponse>({
       message,
       callID: this.callId,
       node_id: this.nodeId,


### PR DESCRIPTION
# Description

The BaseConnection.unhold was missing the `await` 

## Type of change

- [ ] Internal refactoring
- [x] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
