### PR TITLE
Fix  ICE Gathering Race Condition

### DIFF
--- a/.changeset/silent-bags-admire.md
+++ b/.changeset/silent-bags-admire.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/webrtc': patch
+---
+
+FIXED ICE Gathering race condition


### PR DESCRIPTION
# Description

There are three independent signals that can result in calling `_sdpReady()` ready in the implementation:
- iceGatheringState changed to `completed`
- iceCandidate event is fires with no candidates
- Ice Gatheing timeout with valid candidates

We want to continue listen to any of these 3 signals allowing us to send the local SDP sooner then later(ms speedup). But we need to prevent the SDK send a second local SDP. 

## Logs showing the case fixed in this PR
```
console.js:36 2025-11-19T15:28:46.923Z - LOCAL SDP <-- Gathering Timeout with valid SDP
console.js:36 2025-11-19T15:28:50.059Z - iceGatheringState: complete 
```

## Type of change

- [ ] Internal refactoring
- [x] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
