### PR TITLE
chore: remove ignored test files from script execution

### DIFF
--- a/scripts/sw-test/runNodeScript.js
+++ b/scripts/sw-test/runNodeScript.js
@@ -10,9 +10,7 @@ const { spawn } = require('node:child_process')
 const ALLOWED_SCRIPT_EXTENSIONS = ['js', 'ts']
 
 const getScriptOptions = (pathname, config) => {
-  // FIXME: Remove these ignored tests when this issue is fixed: https://github.com/signalwire/cloud-product/issues/17686
-  const ignoreFiles =
-    [...(config.ignoreFiles || []), 'chat.test.ts', 'pubSub.test.ts'] || []
+  const ignoreFiles = config.ignoreFiles || []
   const ignoreDirectories = config.ignoreDirectories
     ? [...config.ignoreDirectories, 'playwright']
     : ['playwright']


### PR DESCRIPTION
# Description

Due to the failure in the APIs, we temporarily ignored the Chat and PubSub tests for the @signalwire/realtime-api package in this PR: https://github.com/signalwire/signalwire-js/pull/1330.

The current PR implementation undoes those ignored test changes.

## Type of change

- [x] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
