### PR TITLE
Enhance call rejection handling and error logging in BaseConnection and VertoEventWorker

### DIFF
--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -35,6 +35,7 @@ import {
   OnVertoByeParams,
 } from './utils/interfaces'
 import { stopTrack, getUserMedia, streamIsValid } from './utils'
+import { safeLogError } from './utils/logError'
 import {
   hasMatchingSdpDirection,
   sdpRemoveLocalCandidates,
@@ -807,7 +808,20 @@ export class BaseConnection<
             await this.peer.start()
             resolve(this as any as T)
           } catch (error) {
-            this.logger.error('Invite error', error)
+            const safeError = safeLogError(error)
+            const maybeError = error as any
+            const isNormalClearing =
+              maybeError?.message === 'NORMAL_CLEARING' &&
+              (maybeError?.code === '16' || maybeError?.code === 16)
+
+            if (isNormalClearing) {
+              this.logger.warn(
+                'Invite rejected (NORMAL_CLEARING)',
+                safeError
+              )
+            } else {
+              this.logger.error('Invite error', safeError)
+            }
             this._destroyPeer()
             reject(error)
           }

--- a/packages/webrtc/src/utils/logError.ts
+++ b/packages/webrtc/src/utils/logError.ts
@@ -1,0 +1,51 @@
+type JsonPrimitive = string | number | boolean | null
+
+const isJsonPrimitive = (value: unknown): value is JsonPrimitive => {
+  return (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  )
+}
+
+/**
+ * Some environments (ex: Call Fabric) attempt to `JSON.stringify` SDK errors.
+ * Errors may contain non-serializable/circular references (ex: internal context).
+ *
+ * This helper extracts only primitive/stack fields to keep logs safe.
+ */
+export const safeLogError = (error: unknown): unknown => {
+  if (!error) return error
+
+  // Plain primitives are always safe.
+  if (isJsonPrimitive(error)) return error
+
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    }
+  }
+
+  if (typeof error === 'object') {
+    const maybe = error as Record<string, unknown>
+
+    const code = maybe.code
+    const message = maybe.message
+    const name = maybe.name
+    const stack = maybe.stack
+
+    return {
+      ...(isJsonPrimitive(name) ? { name } : {}),
+      ...(isJsonPrimitive(message) ? { message } : {}),
+      ...(isJsonPrimitive(code) ? { code } : {}),
+      ...(typeof stack === 'string' ? { stack } : {}),
+    }
+  }
+
+  // Fallback for functions/symbols/etc.
+  return String(error)
+}
+

--- a/packages/webrtc/src/workers/vertoEventWorker.ts
+++ b/packages/webrtc/src/workers/vertoEventWorker.ts
@@ -15,6 +15,7 @@ import {
 } from '@signalwire/core'
 
 import { BaseConnection } from '../BaseConnection'
+import { safeLogError } from '../utils/logError'
 
 type VertoEventWorkerOnDone = (args: BaseConnection<any>) => void
 type VertoEventWorkerOnFail = (args: { error: Error }) => void
@@ -151,7 +152,7 @@ export const vertoEventWorker: SDKWorker<
   const catchableWorker = sagaHelpers.createCatchableSaga<
     MapToPubSubShape<WebRTCMessageParams>
   >(worker, (error) => {
-    getLogger().error('Verto Error', error)
+    getLogger().error('Verto Error', safeLogError(error))
   })
 
   try {


### PR DESCRIPTION
# Description

This PR improves how the SDK logs and classifies call teardown scenarios, especially when a callee rejects or times out an incoming call and the caller receives NORMAL_CLEARING (causeCode: 16). It also prevents host apps (e.g., Call Fabric) from throwing Converting circular structure to JSON when they attempt to JSON.stringify() rich error objects emitted by the SDK.

Fixes: #17006 (reduce noisy “Invite error” logging for expected rejected-call flows) and mitigates circular JSON logging crashes in host environments.

## Type of change

- [ ] Internal refactoring
- [x] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

N/A (no new feature or breaking changes).
