### PR TITLE
Fix: Session auth error event

### DIFF
--- a/.changeset/huge-walls-brush.md
+++ b/.changeset/huge-walls-brush.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': patch
+---
+
+Fix: Authentication errors (-32002) during signalwire.connect now correctly disconnect the client without retrying. Transient server errors during connect now trigger a reconnect instead of being misreported as auth failures. Fixed a hang when calling disconnect() after an auth error.

--- a/internal/e2e-realtime-api/src/client.test.ts
+++ b/internal/e2e-realtime-api/src/client.test.ts
@@ -177,8 +177,9 @@ const handler = async () => {
 
   unsub()
 
-  // --- Test auth error with bad token ---
+  // --- Test auth error with bad token (constructor listen) ---
 
+  let badReconnectingCount = 0
   const authError = promiseWithTimeout<AuthError>(10_000, 'onAuthError')
 
   const badClient = await SignalWire({
@@ -188,6 +189,9 @@ const handler = async () => {
     listen: {
       onAuthError: (error) => {
         authError.resolve(error)
+      },
+      onReconnecting: () => {
+        badReconnectingCount += 1
       },
     },
   })
@@ -206,9 +210,64 @@ const handler = async () => {
     'number',
     'constructor listen: AuthError includes code'
   )
+  tap.equal(
+    badReconnectingCount,
+    0,
+    'auth error must NOT trigger reconnecting (no retry on -32002)'
+  )
+
+  // --- Test auth error via client.listen() ---
+
+  const listenAuthError = promiseWithTimeout<AuthError>(
+    10_000,
+    'listen onAuthError'
+  )
+  let listenBadReconnectingCount = 0
+
+  const badClient2 = await SignalWire({
+    host: process.env.RELAY_HOST || 'relay.swire.io',
+    project: process.env.RELAY_PROJECT as string,
+    token: `${process.env.RELAY_TOKEN as string}-invalid`,
+  })
+
+  const unsubBadClient = badClient2.listen({
+    onAuthError: (error) => {
+      listenAuthError.resolve(error)
+    },
+    onReconnecting: () => {
+      listenBadReconnectingCount += 1
+    },
+  })
+
+  const listenError = await listenAuthError.promise
+
+  tap.ok(listenError, 'client.listen: onAuthError called')
+  tap.equal(listenError.name, 'AuthError', 'client.listen: AuthError received')
+  tap.equal(
+    typeof listenError.code,
+    'number',
+    'client.listen: AuthError includes code'
+  )
+  tap.equal(
+    badClient2.authStatus,
+    'unauthorized',
+    'client.listen: authStatus is "unauthorized" after auth error'
+  )
+  tap.equal(
+    listenBadReconnectingCount,
+    0,
+    'client.listen: auth error must NOT trigger reconnecting'
+  )
+
+  unsubBadClient()
 
   await Promise.race([
     badClient.disconnect(),
+    new Promise((r) => setTimeout(r, 3_000)),
+  ])
+
+  await Promise.race([
+    badClient2.disconnect(),
     new Promise((r) => setTimeout(r, 3_000)),
   ])
 
@@ -219,7 +278,7 @@ async function main() {
   const runner = createTestRunner({
     name: 'SWClient Listen E2E',
     testHandler: handler,
-    executionTime: 30_000,
+    executionTime: 60_000,
   })
 
   await runner.run()

--- a/internal/e2e-realtime-api/src/client.test.ts
+++ b/internal/e2e-realtime-api/src/client.test.ts
@@ -22,6 +22,8 @@ function promiseWithTimeout<T = void>(ms: number, label: string) {
 }
 
 const handler = async () => {
+  // --- Phase 1: Connect with constructor listen ---
+
   let connectedCount = 0
   let disconnectedCount = 0
   let reconnectingCount = 0
@@ -55,7 +57,12 @@ const handler = async () => {
   )
   tap.equal(connectedCount, 1, 'constructor listen: onConnected called once')
 
-  // --- Test client.listen + unsub + reconnect ---
+  const store = client._client?.store
+  if (!store) {
+    throw new Error('Missing store')
+  }
+
+  // --- Phase 2: Reconnect + client.listen + unsub ---
 
   let listenConnectedCount = 0
   let listenDisconnectedCount = 0
@@ -91,21 +98,10 @@ const handler = async () => {
     },
   })
 
-  // Internal access: we don't have a public API to force reconnect.
-  const store = client?._client?.store
-  if (!store) {
-    throw new Error('Missing store for reconnect test')
-  }
-
-  // Ensure unsub works: none of these callbacks should fire after this.
+  // Unsub before triggering events - these callbacks should never fire.
   unsubToSkip()
 
-  // Force close the WebSocket to trigger a real reconnect cycle.
-  store.dispatch(actions.sessionForceCloseAction())
-
-  await reconnecting.promise
-
-  // Wait for the session to fully reconnect before disconnecting.
+  // Wait for the session to fully reconnect before continuing.
   const reconnected = promiseWithTimeout(10_000, 'reconnected')
   const checkUnsub = client.listen({
     onConnected: () => {
@@ -113,6 +109,11 @@ const handler = async () => {
       reconnected.resolve()
     },
   })
+
+  // Force close the WebSocket to trigger a real reconnect cycle.
+  store.dispatch(actions.sessionForceCloseAction())
+
+  await reconnecting.promise
   await reconnected.promise
 
   tap.equal(
@@ -120,24 +121,10 @@ const handler = async () => {
     'authorized',
     'authStatus is "authorized" after reconnect'
   )
-
-  await client.disconnect()
-
-  tap.equal(
-    client.authStatus,
-    'unauthorized',
-    'authStatus is "unauthorized" after disconnect'
-  )
-
   tap.equal(
     connectedCount,
     2,
     'constructor listen: onConnected called twice (initial + reconnect)'
-  )
-  tap.equal(
-    disconnectedCount,
-    1,
-    'constructor listen: onDisconnected called once'
   )
   tap.equal(
     reconnectingCount,
@@ -145,14 +132,14 @@ const handler = async () => {
     'constructor listen: onReconnecting called once'
   )
   tap.equal(
-    listenDisconnectedCount,
-    1,
-    'client.listen: onDisconnected called once'
-  )
-  tap.equal(
     listenConnectedCount,
     1,
     'client.listen: onConnected called once after reconnect'
+  )
+  tap.equal(
+    listenDisconnectedCount,
+    0,
+    'client.listen: onDisconnected not called during reconnect'
   )
   tap.equal(
     listenReconnectingCount,
@@ -177,7 +164,57 @@ const handler = async () => {
 
   unsub()
 
-  // --- Test auth error with bad token ---
+  // --- Phase 3: Auth error via client.listen (reconnect with bad token) ---
+  // Reuse the same connected client. Inject a bad token and force a reconnect
+  // so the signalwire.connect request fails with an auth error.
+
+  const listenAuthError = promiseWithTimeout<AuthError>(
+    10_000,
+    'listen onAuthError'
+  )
+
+  const unsubAuthError = client.listen({
+    onAuthError: (error) => {
+      listenAuthError.resolve(error)
+    },
+  })
+
+  store.dispatch(
+    actions.setTokenAction({
+      token: `${process.env.RELAY_TOKEN as string}-invalid`,
+    })
+  )
+  store.dispatch(actions.sessionForceCloseAction())
+
+  const listenError = await listenAuthError.promise
+
+  tap.ok(listenError, 'client.listen: onAuthError called')
+  tap.equal(listenError.name, 'AuthError', 'client.listen: AuthError received')
+  tap.equal(
+    typeof listenError.code,
+    'number',
+    'client.listen: AuthError includes code'
+  )
+  tap.equal(
+    client.authStatus,
+    'unauthorized',
+    'authStatus is "unauthorized" after auth error'
+  )
+
+  unsubAuthError()
+
+  await Promise.race([
+    client.disconnect(),
+    new Promise((r) => setTimeout(r, 3_000)),
+  ])
+
+  tap.equal(
+    disconnectedCount,
+    1,
+    'constructor listen: onDisconnected called once'
+  )
+
+  // --- Phase 4: Auth error with bad token (constructor listen, new client) ---
 
   let badReconnectingCount = 0
   const authError = promiseWithTimeout<AuthError>(10_000, 'onAuthError')
@@ -201,7 +238,7 @@ const handler = async () => {
   tap.equal(
     badClient.authStatus,
     'unauthorized',
-    'authStatus is "unauthorized" after auth error'
+    'constructor listen: authStatus is "unauthorized" after auth error'
   )
   tap.ok(error, 'constructor listen: onAuthError called')
   tap.equal(error.name, 'AuthError', 'constructor listen: AuthError received')

--- a/internal/e2e-realtime-api/src/client.test.ts
+++ b/internal/e2e-realtime-api/src/client.test.ts
@@ -216,58 +216,8 @@ const handler = async () => {
     'auth error must NOT trigger reconnecting (no retry on -32002)'
   )
 
-  // --- Test auth error via client.listen() ---
-
-  const listenAuthError = promiseWithTimeout<AuthError>(
-    10_000,
-    'listen onAuthError'
-  )
-  let listenBadReconnectingCount = 0
-
-  const badClient2 = await SignalWire({
-    host: process.env.RELAY_HOST || 'relay.swire.io',
-    project: process.env.RELAY_PROJECT as string,
-    token: `${process.env.RELAY_TOKEN as string}-invalid`,
-  })
-
-  const unsubBadClient = badClient2.listen({
-    onAuthError: (error) => {
-      listenAuthError.resolve(error)
-    },
-    onReconnecting: () => {
-      listenBadReconnectingCount += 1
-    },
-  })
-
-  const listenError = await listenAuthError.promise
-
-  tap.ok(listenError, 'client.listen: onAuthError called')
-  tap.equal(listenError.name, 'AuthError', 'client.listen: AuthError received')
-  tap.equal(
-    typeof listenError.code,
-    'number',
-    'client.listen: AuthError includes code'
-  )
-  tap.equal(
-    badClient2.authStatus,
-    'unauthorized',
-    'client.listen: authStatus is "unauthorized" after auth error'
-  )
-  tap.equal(
-    listenBadReconnectingCount,
-    0,
-    'client.listen: auth error must NOT trigger reconnecting'
-  )
-
-  unsubBadClient()
-
   await Promise.race([
     badClient.disconnect(),
-    new Promise((r) => setTimeout(r, 3_000)),
-  ])
-
-  await Promise.race([
-    badClient2.disconnect(),
     new Promise((r) => setTimeout(r, 3_000)),
   ])
 

--- a/internal/e2e-realtime-api/src/client.test.ts
+++ b/internal/e2e-realtime-api/src/client.test.ts
@@ -177,7 +177,7 @@ const handler = async () => {
 
   unsub()
 
-  // --- Test auth error with bad token (constructor listen) ---
+  // --- Test auth error with bad token ---
 
   let badReconnectingCount = 0
   const authError = promiseWithTimeout<AuthError>(10_000, 'onAuthError')

--- a/internal/e2e-realtime-api/src/client.test.ts
+++ b/internal/e2e-realtime-api/src/client.test.ts
@@ -255,7 +255,7 @@ const handler = async () => {
 
   await Promise.race([
     badClient.disconnect(),
-    new Promise((r) => setTimeout(r, 3_000)),
+    new Promise((r) => setTimeout(r, 5_000)),
   ])
 
   return 0

--- a/packages/core/src/BaseSession.test.ts
+++ b/packages/core/src/BaseSession.test.ts
@@ -1,6 +1,10 @@
 import WS from 'jest-websocket-mock'
 import { BaseSession } from './BaseSession'
-import { socketMessageAction, sessionReconnectingAction } from './redux/actions'
+import {
+  socketMessageAction,
+  sessionReconnectingAction,
+  authErrorAction,
+} from './redux/actions'
 import {
   RPCConnect,
   RPCPing,
@@ -8,6 +12,7 @@ import {
   RPCDisconnectResponse,
 } from './RPCMessages'
 import { SWCloseEvent } from './utils'
+import { JSONRPCErrorCode } from './utils/constants'
 import { wait } from './testUtils'
 
 jest.mock('uuid', () => {
@@ -194,6 +199,84 @@ describe('BaseSession', () => {
       )
 
       session.disconnect()
+    })
+  })
+
+  describe('signalwire.connect error handling', () => {
+    function createErrorServer(code: number, message: string) {
+      WS.clean()
+      const errorWs = new WS(host)
+      errorWs.on('connection', (socket: any) => {
+        socket.on('message', (data: any) => {
+          const parsedData = JSON.parse(data)
+          if (parsedData.method === 'signalwire.connect') {
+            socket.send(
+              JSON.stringify({
+                jsonrpc: '2.0',
+                id: parsedData.id,
+                error: { code, message },
+              })
+            )
+          }
+        })
+      })
+      return errorWs
+    }
+
+    it('should emit auth error for -32002 (AUTHENTICATION_FAILED)', async () => {
+      const errorWs = createErrorServer(
+        JSONRPCErrorCode.AUTHENTICATION_FAILED,
+        'Authentication service failed with status ProtocolError, 401 Unauthorized: {}'
+      )
+
+      session.connect()
+      await errorWs.connected
+      await wait(10)
+
+      expect(session.dispatch).toHaveBeenCalledWith(
+        authErrorAction({
+          error: {
+            code: JSONRPCErrorCode.AUTHENTICATION_FAILED,
+            message:
+              'Authentication service failed with status ProtocolError, 401 Unauthorized: {}',
+          },
+        })
+      )
+    })
+
+    it('should reconnect for -32603 (INTERNAL_ERROR) instead of emitting auth error', async () => {
+      const errorWs = createErrorServer(
+        JSONRPCErrorCode.INTERNAL_ERROR,
+        'Internal error'
+      )
+
+      session.connect()
+      await errorWs.connected
+      await wait(10)
+
+      const dispatches = (session.dispatch as jest.Mock).mock.calls
+      const authErrors = dispatches.filter(
+        ([action]: any) =>
+          action.type === authErrorAction({ error: {} as any }).type
+      )
+      expect(authErrors).toHaveLength(0)
+      expect(session.status).toBe('reconnecting')
+    })
+
+    it('should reconnect for unknown error codes instead of emitting auth error', async () => {
+      const errorWs = createErrorServer(-32000, 'Timeout')
+
+      session.connect()
+      await errorWs.connected
+      await wait(10)
+
+      const dispatches = (session.dispatch as jest.Mock).mock.calls
+      const authErrors = dispatches.filter(
+        ([action]: any) =>
+          action.type === authErrorAction({ error: {} as any }).type
+      )
+      expect(authErrors).toHaveLength(0)
+      expect(session.status).toBe('reconnecting')
     })
   })
 

--- a/packages/core/src/BaseSession.ts
+++ b/packages/core/src/BaseSession.ts
@@ -11,6 +11,7 @@ import {
 } from './utils'
 import {
   DEFAULT_HOST,
+  JSONRPCErrorCode,
   SYMBOL_CONNECT_ERROR,
   SYMBOL_EXECUTE_CONNECTION_CLOSED,
   SYMBOL_EXECUTE_TIMEOUT,
@@ -422,6 +423,7 @@ export class BaseSession {
       this._flushExecuteQueue()
       this.dispatch(authSuccessAction())
     } catch (error) {
+      // Connection closed or the timeout error
       if (
         error === this._swConnectError ||
         error === this._executeConnectionClosed
@@ -432,8 +434,17 @@ export class BaseSession {
         return
       }
 
-      this.logger.error('Auth Error', error)
-      this.authError(error)
+      // Handle authentication error and retry on internal errors
+      if (error?.code === JSONRPCErrorCode.AUTHENTICATION_FAILED) {
+        this.logger.error('Auth Error', error)
+        this.authError(error)
+      } else {
+        this.logger.warn(
+          'Non-auth error during signalwire.connect, retrying',
+          error
+        )
+        this._closeConnection('reconnecting')
+      }
     }
   }
 

--- a/packages/core/src/BaseSession.ts
+++ b/packages/core/src/BaseSession.ts
@@ -294,6 +294,12 @@ export class BaseSession {
      */
     if (!this._socket || this.closing) {
       this.logger.debug('Session not connected or already in closing state.')
+      // After an auth error the socket may be closing/closed but
+      // sessionDisconnectedAction was never dispatched, so complete
+      // the disconnect lifecycle to avoid hanging callers.
+      if (this._status !== 'disconnected') {
+        this._closeConnection('disconnected')
+      }
       return
     }
 

--- a/packages/core/src/BaseSession.ts
+++ b/packages/core/src/BaseSession.ts
@@ -437,6 +437,7 @@ export class BaseSession {
       // Handle authentication error and retry on internal errors
       if (error?.code === JSONRPCErrorCode.AUTHENTICATION_FAILED) {
         this.logger.error('Auth Error', error)
+        // TBD: Should we cleanup the SDK and destroy the session on auth error?
         this.authError(error)
       } else {
         this.logger.warn(

--- a/packages/core/src/redux/actions.ts
+++ b/packages/core/src/redux/actions.ts
@@ -32,6 +32,13 @@ export const sessionReconnectingAction = createAction<void, SessionEvents>(
 export const sessionForceCloseAction = createAction<void, SessionActions>(
   'session.forceClose'
 )
+/**
+ * @internal Used in tests to override the session token without
+ * triggering reauthentication.
+ */
+export const setTokenAction = createAction<{ token: string }>(
+  'swSdk/setToken'
+)
 const formatCustomSagaAction = (id: string, action: Action) => {
   return `${action.type}/${id}`
 }

--- a/packages/core/src/redux/rootSaga.test.ts
+++ b/packages/core/src/redux/rootSaga.test.ts
@@ -18,6 +18,7 @@ import {
   destroyAction,
   initAction,
   reauthAction,
+  setTokenAction,
 } from './actions'
 import { AuthError } from '../CustomErrors'
 import { createSwEventChannel, createSessionChannel } from '../testUtils'
@@ -30,6 +31,7 @@ describe('sessionStatusWatcher', () => {
     reauthAction.type,
     sessionReconnectingAction.type,
     sessionForceCloseAction.type,
+    setTokenAction.type,
   ]
   const session = {
     closed: true,
@@ -97,6 +99,18 @@ describe('sessionStatusWatcher', () => {
     saga.next(authExpiringAction())
 
     expect(sessionEmitter.emit).toHaveBeenCalledWith('session.expiring')
+
+    // Saga waits again for actions due to the while loop
+    saga.next()
+  })
+
+  it('should set session.token on setTokenAction', () => {
+    const saga = testSaga(sessionStatusWatcher, options)
+
+    saga.next().take(actions)
+    saga.next(setTokenAction({ token: 'new-token' }))
+
+    expect(session.token).toBe('new-token')
 
     // Saga waits again for actions due to the while loop
     saga.next()

--- a/packages/core/src/redux/rootSaga.ts
+++ b/packages/core/src/redux/rootSaga.ts
@@ -15,6 +15,7 @@ import {
   sessionDisconnectedAction,
   reauthAction,
   sessionForceCloseAction,
+  setTokenAction,
 } from './actions'
 import { sessionActions } from './features'
 import {
@@ -149,6 +150,7 @@ export function* sessionStatusWatcher(options: StartSagaOptions): SagaIterator {
         reauthAction.type,
         sessionReconnectingAction.type,
         sessionForceCloseAction.type,
+        setTokenAction.type,
       ])
 
       getLogger().debug('sessionStatusWatcher', action.type, action.payload)
@@ -183,6 +185,10 @@ export function* sessionStatusWatcher(options: StartSagaOptions): SagaIterator {
         }
         case sessionForceCloseAction.type: {
           session.forceClose()
+          break
+        }
+        case setTokenAction.type: {
+          session.token = action.payload.token
           break
         }
       }

--- a/packages/core/src/utils/constants.ts
+++ b/packages/core/src/utils/constants.ts
@@ -57,6 +57,15 @@ export const INTERNAL_GLOBAL_VIDEO_EVENTS = GLOBAL_VIDEO_EVENTS.map(
   (event) => `${PRODUCT_PREFIX_VIDEO}.${event}` as const
 )
 
+/**
+ * JSON-RPC error codes returned by the Hagrid.
+ * @see https://www.jsonrpc.org/specification#error_object
+ */
+export const JSONRPCErrorCode = {
+  AUTHENTICATION_FAILED: -32002,
+  INTERNAL_ERROR: -32603,
+} as const
+
 export const SYMBOL_EXECUTE_CONNECTION_CLOSED = Symbol.for(
   'sw-execute-connection-closed'
 )


### PR DESCRIPTION
# Description

  - Authentication errors (-32002) from `signalwire.connect` now cleanly disconnect without triggering reconnect attempts                     
  - Transient/internal server errors during connect now correctly trigger a reconnect instead of being treated as auth failures
  - Fixed `disconnect()` hanging when called after an auth error (socket already closing, but disconnect lifecycle never completed)
 
## Type of change

- [ ] Internal refactoring
- [x] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

The following event listener will now only be called for the REAL auth error. For the other errors, the SDK will retry the `signalwire.connect`

```ts
const client = await SignalWire({
  project: '<project-id>',
  token: '<api-token>',
  listen: {
    onAuthError: (error) => console.log('Auth error', error),
  },
})
```
